### PR TITLE
Fix agent gh CLI auth in Docker container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# GitHub Personal Access Token for the agent's gh CLI.
+# Create a classic PAT with 'repo' and 'read:org' scopes.
+# Copy this file to .env and fill in the value.
+GH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Environment files (contain secrets)
+.env
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -205,7 +205,13 @@ ChemSim uses AI agents to implement features from GitHub Issues. See [AGENTS.md]
 
 **Option A — Dev container (recommended):**
 ```bash
-# Ensure your Anthropic proxy is running on localhost:4141
+# 1. Copy .env.example to .env and add your GitHub PAT
+cp .env.example .env
+# Edit .env and set GH_TOKEN=ghp_...
+
+# 2. Ensure your Anthropic proxy is running on localhost:4141
+
+# 3. Launch the agent
 docker compose run --rm agent
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 # docker-compose.yml — Launch an isolated Claude Code agent in a container.
 #
 # Usage:
-#   docker compose run --rm agent
+#   1. Copy .env.example to .env and fill in your GH_TOKEN
+#   2. docker compose run --rm agent
 #
 # The container:
 #   - Uses the dev container image (Node 20 + gh CLI + Claude Code)
-#   - Mounts your gh CLI auth (read-only) so the agent can use gh commands
+#   - Authenticates gh CLI via GH_TOKEN env var (from .env file)
 #   - Connects to the host's Anthropic proxy on port 4141
 #   - Clones the repo, then launches Claude Code pointed at AGENTS.md
 #   - Claude Code handles everything: issue selection, branching, implementation, PR
@@ -23,13 +24,12 @@ services:
       - ANTHROPIC_DEFAULT_SONNET_MODEL=claude-opus-4.6-1m
       - ANTHROPIC_SMALL_FAST_MODEL=claude-opus-4.6-1m
       - ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-opus-4.6-1m
+      # GitHub auth for gh CLI — set in .env file
+      - GH_TOKEN=${GH_TOKEN}
     extra_hosts:
       # Allows the container to reach the host machine's services
       - "host.docker.internal:host-gateway"
-    volumes:
-      # Mount gh CLI auth so the container can use gh commands
-      - ${HOME}/.config/gh:/home/node/.config/gh:ro
     working_dir: /workspace
     stdin_open: true
     tty: true
-    command: bash -c "git clone https://github.com/sam0109/chem_sim.git /workspace/chem_sim && cd /workspace/chem_sim && npm install && exec claude --dangerously-skip-permissions --print 'Follow AGENTS.md'"
+    command: bash -c "git clone https://github.com/sam0109/chem_sim.git /workspace/chem_sim && cd /workspace/chem_sim && git config user.name 'samsobellassistant' && git config user.email 'samsobellassistant@users.noreply.github.com' && npm install && exec claude --dangerously-skip-permissions --print 'Follow AGENTS.md'"


### PR DESCRIPTION
## Summary
- The dev container agent workflow failed because `gh` CLI had no valid token — macOS stores it in Keychain, which isn't accessible inside Docker
- Switch from mounting `~/.config/gh` to passing `GH_TOKEN` env var via a `.env` file
- Configure git identity as `samsobellassistant` inside the container

## Changes
- **docker-compose.yml** — Replace volume mount with `GH_TOKEN` env var; add git config for samsobellassistant
- **.env.example** — New template showing what to put in `.env`
- **.gitignore** — Add `.env` (but not `.env.example`) to prevent token leaks
- **README.md** — Update Option A instructions to include `.env` setup step

## Test Results
- Built container, verified `gh auth status` shows `samsobellassistant` authenticated
- Ran full AGENTS.md workflow end-to-end: agent claimed issue #50, implemented it, opened PR #60, reviewed, merged, and closed the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)