### PR TITLE
Fix agent output not appearing in docker logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,4 @@ services:
       # Allows the container to reach the host machine's services
       - "host.docker.internal:host-gateway"
     working_dir: /workspace
-    stdin_open: true
-    tty: true
-    command: bash -c "git clone https://github.com/sam0109/chem_sim.git /workspace/chem_sim && cd /workspace/chem_sim && git config user.name 'samsobellassistant' && git config user.email 'samsobellassistant@users.noreply.github.com' && npm install && exec claude --dangerously-skip-permissions --print 'Follow AGENTS.md'"
+    command: bash -c "git clone https://github.com/sam0109/chem_sim.git /workspace/chem_sim && cd /workspace/chem_sim && git config user.name 'samsobellassistant' && git config user.email 'samsobellassistant@users.noreply.github.com' && npm install && exec claude --dangerously-skip-permissions --print 'Follow AGENTS.md' 2>&1"


### PR DESCRIPTION
## Summary
- Remove `stdin_open: true` and `tty: true` from docker-compose.yml — the pseudo-TTY was capturing stdout internally, making `docker logs` empty for detached (`-d`) containers
- Add `2>&1` to merge stderr into stdout so errors are also visible in logs

## Test plan
- [ ] Run `docker compose run --rm -d agent` and verify `docker logs <id>` shows Claude Code output
- [ ] Verify `docker compose run --rm agent` (foreground) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)