### PR TITLE
6.8 Export simulation as shareable lesson (#43)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,38 @@ const headerButtonStyle: React.CSSProperties = {
   backdropFilter: 'blur(10px)',
 };
 
+// Shared style for items in dropdown menus (examples, share, etc.)
+const dropdownItemStyle: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  padding: '6px 10px',
+  border: 'none',
+  background: 'transparent',
+  color: '#ccc',
+  cursor: 'pointer',
+  fontFamily: 'monospace',
+  fontSize: 11,
+  textAlign: 'left',
+  borderRadius: 3,
+};
+
+const dropdownContainerStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '100%',
+  marginTop: 4,
+  background: 'rgba(20, 20, 40, 0.98)',
+  borderRadius: 6,
+  border: '1px solid rgba(255,255,255,0.1)',
+  padding: 4,
+  zIndex: 200,
+};
+
+/** Hover handlers for dropdown items */
+const onItemHover = (e: React.MouseEvent<HTMLButtonElement>) =>
+  (e.currentTarget.style.background = 'rgba(100,150,255,0.2)');
+const onItemLeave = (e: React.MouseEvent<HTMLButtonElement>) =>
+  (e.currentTarget.style.background = 'transparent');
+
 const App: React.FC = () => {
   const initWorker = useSimulationStore((s) => s.initWorker);
   const initSimulation = useSimulationStore((s) => s.initSimulation);
@@ -75,9 +107,8 @@ const App: React.FC = () => {
         cutoff: file.config.cutoff,
       });
       setRenderMode(file.ui.renderMode);
-      if (file.ui.showLabels !== useUIStore.getState().showLabels) {
-        useUIStore.getState().toggleLabels();
-      }
+      // Set showLabels directly to avoid read-then-toggle race
+      useUIStore.setState({ showLabels: file.ui.showLabels });
       setColorMode(file.ui.colorMode);
     },
     [initSimulation, setConfig, setRenderMode, setColorMode],
@@ -235,44 +266,16 @@ const App: React.FC = () => {
             {showExamples && (
               <div
                 data-testid="examples-dropdown"
-                style={{
-                  position: 'absolute',
-                  top: '100%',
-                  left: 0,
-                  marginTop: 4,
-                  background: 'rgba(20, 20, 40, 0.98)',
-                  borderRadius: 6,
-                  border: '1px solid rgba(255,255,255,0.1)',
-                  padding: 4,
-                  minWidth: 180,
-                  zIndex: 200,
-                }}
+                style={{ ...dropdownContainerStyle, left: 0, minWidth: 180 }}
               >
                 {Object.keys(exampleMolecules).map((name) => (
                   <button
                     key={name}
                     data-testid={`example-${name}`}
                     onClick={() => handleLoadExample(name)}
-                    style={{
-                      display: 'block',
-                      width: '100%',
-                      padding: '6px 10px',
-                      border: 'none',
-                      background: 'transparent',
-                      color: '#ccc',
-                      cursor: 'pointer',
-                      fontFamily: 'monospace',
-                      fontSize: 11,
-                      textAlign: 'left',
-                      borderRadius: 3,
-                    }}
-                    onMouseEnter={(e) =>
-                      (e.currentTarget.style.background =
-                        'rgba(100,150,255,0.2)')
-                    }
-                    onMouseLeave={(e) =>
-                      (e.currentTarget.style.background = 'transparent')
-                    }
+                    style={dropdownItemStyle}
+                    onMouseEnter={onItemHover}
+                    onMouseLeave={onItemLeave}
                   >
                     {name}
                   </button>
@@ -302,66 +305,23 @@ const App: React.FC = () => {
             {showShareMenu && (
               <div
                 data-testid="share-dropdown"
-                style={{
-                  position: 'absolute',
-                  top: '100%',
-                  right: 0,
-                  marginTop: 4,
-                  background: 'rgba(20, 20, 40, 0.98)',
-                  borderRadius: 6,
-                  border: '1px solid rgba(255,255,255,0.1)',
-                  padding: 4,
-                  minWidth: 160,
-                  zIndex: 200,
-                }}
+                style={{ ...dropdownContainerStyle, right: 0, minWidth: 160 }}
               >
                 <button
                   data-testid="copy-link-button"
                   onClick={handleCopyLink}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    padding: '6px 10px',
-                    border: 'none',
-                    background: 'transparent',
-                    color: '#ccc',
-                    cursor: 'pointer',
-                    fontFamily: 'monospace',
-                    fontSize: 11,
-                    textAlign: 'left',
-                    borderRadius: 3,
-                  }}
-                  onMouseEnter={(e) =>
-                    (e.currentTarget.style.background = 'rgba(100,150,255,0.2)')
-                  }
-                  onMouseLeave={(e) =>
-                    (e.currentTarget.style.background = 'transparent')
-                  }
+                  style={dropdownItemStyle}
+                  onMouseEnter={onItemHover}
+                  onMouseLeave={onItemLeave}
                 >
                   Copy Link
                 </button>
                 <button
                   data-testid="save-chemsim-button"
                   onClick={handleSaveFile}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    padding: '6px 10px',
-                    border: 'none',
-                    background: 'transparent',
-                    color: '#ccc',
-                    cursor: 'pointer',
-                    fontFamily: 'monospace',
-                    fontSize: 11,
-                    textAlign: 'left',
-                    borderRadius: 3,
-                  }}
-                  onMouseEnter={(e) =>
-                    (e.currentTarget.style.background = 'rgba(100,150,255,0.2)')
-                  }
-                  onMouseLeave={(e) =>
-                    (e.currentTarget.style.background = 'transparent')
-                  }
+                  style={dropdownItemStyle}
+                  onMouseEnter={onItemHover}
+                  onMouseLeave={onItemLeave}
                 >
                   Save .chemsim
                 </button>

--- a/src/io/chemsimFile.ts
+++ b/src/io/chemsimFile.ts
@@ -172,8 +172,16 @@ function isVector3Tuple(v: unknown): v is [number, number, number] {
     v.length === 3 &&
     typeof v[0] === 'number' &&
     typeof v[1] === 'number' &&
-    typeof v[2] === 'number'
+    typeof v[2] === 'number' &&
+    Number.isFinite(v[0]) &&
+    Number.isFinite(v[1]) &&
+    Number.isFinite(v[2])
   );
+}
+
+/** Check that a value is a finite number */
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
 }
 
 /** Validate a parsed JSON object as a ChemSimFileV1. Throws on invalid data. */
@@ -196,11 +204,17 @@ export function validateChemSimFile(data: unknown): ChemSimFileV1 {
   }
   for (let i = 0; i < obj.atoms.length; i++) {
     const a = obj.atoms[i] as Record<string, unknown>;
-    if (typeof a.id !== 'number') {
+    if (!isFiniteNumber(a.id)) {
       throw new Error(`Invalid atom[${i}]: missing or invalid id`);
     }
-    if (typeof a.elementNumber !== 'number' || a.elementNumber < 1) {
-      throw new Error(`Invalid atom[${i}]: missing or invalid elementNumber`);
+    // Atomic numbers range from 1 (H) to 118 (Og)
+    if (
+      typeof a.elementNumber !== 'number' ||
+      !Number.isInteger(a.elementNumber) ||
+      a.elementNumber < 1 ||
+      a.elementNumber > 118
+    ) {
+      throw new Error(`Invalid atom[${i}]: elementNumber must be 1-118`);
     }
     if (!isVector3Tuple(a.position)) {
       throw new Error(`Invalid atom[${i}]: position must be [x, y, z]`);
@@ -208,7 +222,7 @@ export function validateChemSimFile(data: unknown): ChemSimFileV1 {
     if (!isVector3Tuple(a.velocity)) {
       throw new Error(`Invalid atom[${i}]: velocity must be [vx, vy, vz]`);
     }
-    if (typeof a.charge !== 'number') {
+    if (!isFiniteNumber(a.charge)) {
       throw new Error(`Invalid atom[${i}]: missing or invalid charge`);
     }
     if (!VALID_HYBRIDIZATIONS.has(a.hybridization as string)) {
@@ -225,10 +239,10 @@ export function validateChemSimFile(data: unknown): ChemSimFileV1 {
   }
   for (let i = 0; i < obj.bonds.length; i++) {
     const b = obj.bonds[i] as Record<string, unknown>;
-    if (typeof b.atomA !== 'number' || typeof b.atomB !== 'number') {
+    if (!isFiniteNumber(b.atomA) || !isFiniteNumber(b.atomB)) {
       throw new Error(`Invalid bond[${i}]: atomA and atomB must be numbers`);
     }
-    if (typeof b.order !== 'number') {
+    if (!isFiniteNumber(b.order)) {
       throw new Error(`Invalid bond[${i}]: order must be a number`);
     }
     if (!VALID_BOND_TYPES.has(b.type as string)) {
@@ -241,10 +255,10 @@ export function validateChemSimFile(data: unknown): ChemSimFileV1 {
   if (typeof cfg !== 'object' || cfg === null) {
     throw new Error('Invalid .chemsim file: config must be an object');
   }
-  if (typeof cfg.timestep !== 'number' || cfg.timestep <= 0) {
+  if (!isFiniteNumber(cfg.timestep) || cfg.timestep <= 0) {
     throw new Error('Invalid config: timestep must be a positive number');
   }
-  if (typeof cfg.temperature !== 'number' || cfg.temperature < 0) {
+  if (!isFiniteNumber(cfg.temperature) || cfg.temperature < 0) {
     throw new Error(
       'Invalid config: temperature must be a non-negative number',
     );
@@ -252,10 +266,10 @@ export function validateChemSimFile(data: unknown): ChemSimFileV1 {
   if (!VALID_THERMOSTATS.has(cfg.thermostat as string)) {
     throw new Error('Invalid config: invalid thermostat type');
   }
-  if (typeof cfg.thermostatTau !== 'number') {
+  if (!isFiniteNumber(cfg.thermostatTau)) {
     throw new Error('Invalid config: thermostatTau must be a number');
   }
-  if (typeof cfg.cutoff !== 'number' || cfg.cutoff <= 0) {
+  if (!isFiniteNumber(cfg.cutoff) || cfg.cutoff <= 0) {
     throw new Error('Invalid config: cutoff must be a positive number');
   }
 
@@ -366,13 +380,26 @@ function fromBase64url(str: string): Uint8Array {
   return bytes;
 }
 
-/** Serialize state → compressed base64url string for URL embedding */
+/** Maximum safe URL parameter length (conservative limit for proxies/servers) */
+const MAX_URL_PARAM_LENGTH = 32_000;
+
+/** Serialize state → compressed base64url string for URL embedding.
+ *  Throws if the compressed result exceeds MAX_URL_PARAM_LENGTH. */
 export async function stateToUrlParam(input: SerializeInput): Promise<string> {
   const state = serializeState(input);
   const json = JSON.stringify(state);
   const encoded = new TextEncoder().encode(json);
   const compressed = await compress(encoded);
-  return toBase64url(compressed);
+  const param = toBase64url(compressed);
+
+  if (param.length > MAX_URL_PARAM_LENGTH) {
+    throw new Error(
+      `Compressed state is too large for URL sharing (${param.length} chars, ` +
+        `max ${MAX_URL_PARAM_LENGTH}). Use "Save .chemsim" for large simulations.`,
+    );
+  }
+
+  return param;
 }
 
 /** Decode a base64url URL parameter → validated ChemSimFileV1 */


### PR DESCRIPTION
Closes #43

## Summary
Adds the ability to share and save simulation state via compressed URL links or `.chemsim` JSON files. Teachers/students can share exact simulation setups (atoms, bonds, config, camera settings) through a URL or downloadable file.

## Changes
- **New file `src/io/chemsimFile.ts`**: ChemSimFileV1 schema with versioning, serialization/deserialization, thorough validation, deflate-raw compression via CompressionStream API, base64url encoding, and file save/load helpers
- **Updated `src/App.tsx`**: 
  - "Share" button with dropdown: "Copy Link" (compressed URL to clipboard) and "Save .chemsim" (file download)
  - "Import" button now accepts both `.xyz` and `.chemsim` files
  - Startup URL parsing: checks for `?scene=` parameter, loads shared state, cleans URL
  - Applies deserialized UI settings (renderMode, labels, colorMode)
  - Extracted shared `headerButtonStyle` constant for consistency

## Test Results
- Physics tests: 27/27 passing (was 27/27 before) — no regressions
- Build: clean
- Type check: clean
- Lint: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #43)
- [x] Specific improvement addressed: shareable simulation state via URL and file export

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (no engine changes)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A (no engine changes)
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source — N/A (no physics constants)

### Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality — follow-up: validation/round-trip tests could be added when a test framework is installed (#47)
- [ ] Tests would FAIL if the feature were broken — no automated UI tests yet (#48)
- [x] Tests are not tautological

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths — serialization only runs on user action

### Documentation
- [x] README.md updated if public API/usage changed — N/A (no public API)
- [x] Complex algorithms have inline comments

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none needed