### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx vite build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import glsl from 'vite-plugin-glsl';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/chem_sim/',
   plugins: [react(), glsl()],
   worker: {
     format: 'es',


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml` using `actions/deploy-pages` to deploy the Vite build output to GitHub Pages
- Set `base: '/chem_sim/'` in `vite.config.ts` so asset paths resolve correctly on `sam0109.github.io/chem_sim/`
- This bypasses the "main branch is protected" error since the workflow uses the Pages API instead of pushing to a branch

## Test plan
- [x] `npx vite build` succeeds with new base path
- [x] YAML validates
- [ ] After merge, the deploy workflow runs and site is live at https://sam0109.github.io/chem_sim/

🤖 Generated with [Claude Code](https://claude.com/claude-code)