### PR TITLE
Encounter setup panel never disappears after launching (#97)

### DIFF
--- a/src/ui/EncounterPanel.tsx
+++ b/src/ui/EncounterPanel.tsx
@@ -17,6 +17,8 @@ import {
 
 export const EncounterPanel: React.FC = () => {
   const showEncounterPanel = useUIStore((s) => s.showEncounterPanel);
+  const toggleEncounterPanel = useUIStore((s) => s.toggleEncounterPanel);
+  const setActiveTool = useUIStore((s) => s.setActiveTool);
   const selectedTemplate = useUIStore((s) => s.selectedMoleculeTemplate);
   const setSelectedTemplate = useUIStore((s) => s.setSelectedMoleculeTemplate);
   const separation = useUIStore((s) => s.encounterSeparation);
@@ -93,6 +95,10 @@ export const EncounterPanel: React.FC = () => {
     const molA = molecules[0];
     const molB = molecules[1];
     launchEncounter(molA.atomIndices, molB.atomIndices, speed, impactParam);
+    // Dismiss the panel and return to the default tool so the user
+    // can observe the encounter without UI obstruction (#97)
+    toggleEncounterPanel();
+    setActiveTool('select');
   };
 
   return (


### PR DESCRIPTION
Closes #97

## Summary
The encounter setup panel remained visible after the user clicked "Launch", obstructing the simulation view. This change dismisses the panel and resets the active tool to 'select' after launching an encounter.

## Changes
- Modified `handleLaunch` in `EncounterPanel.tsx` to call `toggleEncounterPanel()` after launching, hiding the panel
- Also resets `activeTool` to `'select'` since the place-molecule tool context is no longer relevant

## Test Results
- Physics tests: 45/45 passing (was 45/45 before — no regressions)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #97)
- [x] Specific improvement addressed: encounter panel dismisses after launch

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (no engine changes)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source — N/A (no new constants)

### Testing
- [x] All existing tests pass
- [x] New tests added for new functionality — N/A (UI behavior, no test framework available per issue #47)
- [x] Tests would FAIL if the feature were broken — N/A
- [x] Tests are not tautological — N/A

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths

### Documentation
- [x] README.md updated if public API/usage changed — N/A
- [x] Complex algorithms have inline comments — N/A

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none needed