### PR TITLE
Fix writeXYZ bug (#20)

### DIFF
--- a/src/io/xyz.ts
+++ b/src/io/xyz.ts
@@ -7,7 +7,7 @@
 // ==============================================================
 
 import type { Atom } from '../data/types';
-import { getElementBySymbol } from '../data/elements';
+import { getElement, getElementBySymbol } from '../data/elements';
 
 /**
  * Parse XYZ file content into atoms.
@@ -60,7 +60,7 @@ export function writeXYZ(
   const lines: string[] = [String(atoms.length), comment];
 
   for (const atom of atoms) {
-    const el = getElementBySymbol(String(atom.elementNumber));
+    const el = getElement(atom.elementNumber);
     const sym = el?.symbol ?? 'X';
     const [x, y, z] = atom.position;
     lines.push(


### PR DESCRIPTION
Closes #20

## Summary
Fixed `writeXYZ()` which was incorrectly passing atomic numbers (e.g., `"8"`) to `getElementBySymbol()`, a function expecting element symbols (e.g., `"O"`). This caused XYZ exports to produce incorrect element symbols or fall back to `"X"` for all atoms.

## Changes
- Changed `writeXYZ()` in `src/io/xyz.ts` to use `getElement(atom.elementNumber)` instead of `getElementBySymbol(String(atom.elementNumber))`
- Added `getElement` to the import from `../data/elements`

## Test Results
- Physics tests: 56/56 passing (no regressions)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #20)
- [x] Specific improvement addressed: XYZ export produces correct element symbols

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (no force changes)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A (no integrator changes)
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source — N/A

### Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality — this is a one-line bug fix in I/O, no test framework installed
- [x] Tests would FAIL if the feature were broken — N/A
- [x] Tests are not tautological — N/A

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths

### Documentation
- [x] README.md updated if public API/usage changed — N/A
- [x] Complex algorithms have inline comments — N/A

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none discovered