### PR TITLE
Periodic table "Link to simulation" — auto-place diatomic and minimize (#90)

### DIFF
--- a/src/ui/PeriodicTable.tsx
+++ b/src/ui/PeriodicTable.tsx
@@ -2,10 +2,15 @@
 // PeriodicTable — interactive element picker with educational features
 // ==============================================================
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useUIStore } from '../store/uiStore';
+import { useSimulationStore } from '../store/simulationStore';
 import elements from '../data/elements';
-import type { ChemicalElement, PeriodicTableColorMode } from '../data/types';
+import type {
+  Atom,
+  ChemicalElement,
+  PeriodicTableColorMode,
+} from '../data/types';
 
 // Periodic table grid layout: [row][col] = atomic number (0 = empty)
 const GRID: number[][] = [
@@ -650,12 +655,61 @@ const CompareBar: React.FC<{
   );
 };
 
+/**
+ * Create a diatomic molecule from two elements for simulation.
+ * Places atom A at the origin and atom B along the x-axis at the
+ * sum of covalent radii + 0.5 Å (a reasonable starting separation
+ * that will relax to equilibrium during minimization).
+ *
+ * Source: initial separation heuristic from issue #90
+ */
+function createDiatomic(elA: ChemicalElement, elB: ChemicalElement): Atom[] {
+  const separation = elA.covalentRadius + elB.covalentRadius + 0.5;
+  return [
+    {
+      id: 0,
+      elementNumber: elA.number,
+      position: [0, 0, 0],
+      velocity: [0, 0, 0],
+      force: [0, 0, 0],
+      charge: 0,
+      hybridization: 'none',
+      fixed: false,
+    },
+    {
+      id: 1,
+      elementNumber: elB.number,
+      position: [separation, 0, 0],
+      velocity: [0, 0, 0],
+      force: [0, 0, 0],
+      charge: 0,
+      hybridization: 'none',
+      fixed: false,
+    },
+  ];
+}
+
 /** Floating comparison card for two elements */
 const ElementComparison: React.FC<{
   elA: ChemicalElement;
   elB: ChemicalElement;
   onClose: () => void;
 }> = ({ elA, elB, onClose }) => {
+  const initSimulation = useSimulationStore((s) => s.initSimulation);
+  const minimize = useSimulationStore((s) => s.minimize);
+
+  const handleSimulateDiatomic = useCallback(async () => {
+    const atoms = createDiatomic(elA, elB);
+    initSimulation(atoms);
+
+    // Brief delay for the web worker to initialize (matches ChallengePanel pattern)
+    await new Promise((r) => setTimeout(r, 500));
+    minimize();
+
+    // Close the comparison card so the simulation view is visible
+    onClose();
+  }, [elA, elB, initSimulation, minimize, onClose]);
+
   const deltaEN = Math.abs(elA.electronegativity - elB.electronegativity);
   const bondPrediction =
     elA.electronegativity > 0 && elB.electronegativity > 0
@@ -806,6 +860,34 @@ const ElementComparison: React.FC<{
           </div>
         </div>
       )}
+
+      {/* Simulate diatomic button */}
+      <button
+        onClick={handleSimulateDiatomic}
+        style={{
+          display: 'block',
+          width: '100%',
+          marginTop: 8,
+          padding: '6px 10px',
+          background: 'rgba(80, 140, 255, 0.15)',
+          border: '1px solid rgba(80, 140, 255, 0.4)',
+          borderRadius: 4,
+          color: '#8ab4ff',
+          fontSize: 11,
+          fontFamily: 'sans-serif',
+          fontWeight: 'bold',
+          cursor: 'pointer',
+          transition: 'background 0.15s',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = 'rgba(80, 140, 255, 0.3)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'rgba(80, 140, 255, 0.15)';
+        }}
+      >
+        Bond {elA.symbol} + {elB.symbol} — Simulate
+      </button>
 
       <div
         style={{


### PR DESCRIPTION
Closes #90

## Summary
Adds a "Bond A + B — Simulate" button to the periodic table element comparison card. When two elements are compared (shift+click), users can click the button to instantly create a diatomic molecule at the appropriate bond distance and run energy minimization. This connects the periodic table's educational features directly to the simulation.

## Changes
- Added `createDiatomic()` helper function that builds two `Atom` objects at the sum of their covalent radii + 0.5 Å separation (relaxes to equilibrium during minimization)
- Added simulation store hooks (`initSimulation`, `minimize`) to the `ElementComparison` component
- Added `handleSimulateDiatomic` async handler that initializes the simulation with the diatomic, waits for worker init, runs minimization, and closes the comparison card
- Added styled "Bond A + B — Simulate" button with hover effect, placed after the bond prediction section in the comparison card

## Test Results
- Physics tests: 56/56 passing (was 56/56 before — no regressions)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #90)
- [x] Specific improvement addressed: interactive "simulate diatomic" button in periodic table comparison card

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (no force computation changes)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A (no integrator changes)
- [x] New potential/force has a gradient consistency test — N/A (no new potentials)
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source (separation heuristic cites issue #90)

### Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality — UI-only change, no test framework available (#47, #48)
- [x] Tests would FAIL if the feature were broken — N/A for UI-only change
- [x] Tests are not tautological

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths

### Documentation
- [x] README.md updated if public API/usage changed — N/A (no API changes)
- [x] Complex algorithms have inline comments

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none needed