### PR TITLE
Fix atoms not showing CPK element colors (#120)

### DIFF
--- a/src/renderer/AtomRenderer.tsx
+++ b/src/renderer/AtomRenderer.tsx
@@ -3,7 +3,7 @@
 // Uses InstancedMesh with per-instance color/scale for performance
 // ==============================================================
 
-import React, { useRef, useMemo } from 'react';
+import React, { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useSimContextStoreApi } from '../store/SimulationContext';
@@ -47,6 +47,19 @@ export const AtomRenderer: React.FC = () => {
     const detail = renderMode === 'space-filling' ? 32 : 16;
     return new THREE.SphereGeometry(1, detail, detail);
   }, [renderMode]);
+
+  // Pre-initialize instanceColor so the material shader compiles with
+  // instance color support. Without this, Three.js compiles the
+  // meshStandardMaterial shader before useFrame first sets instanceColor,
+  // and vertexColors never takes effect. (See issue #120)
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    mesh.instanceColor = new THREE.InstancedBufferAttribute(
+      new Float32Array(MAX_ATOMS * 3),
+      3,
+    );
+  }, []);
 
   useFrame(() => {
     const mesh = meshRef.current;


### PR DESCRIPTION
Closes #120

## Summary
Atoms in the 3D scene all appeared the same color instead of being colored by element (CPK/Jmol convention). The root cause was that `instanceColor` was created lazily inside `useFrame`, which runs after Three.js has already compiled the `meshStandardMaterial` shader — so the shader never included instance color support.

## Changes
- Added a `useEffect` in `AtomRenderer.tsx` that pre-initializes the `instanceColor` attribute on the `InstancedMesh` immediately after mount, ensuring it exists when Three.js first compiles the material shader with `vertexColors`

## Test Results
- Physics tests: 66/66 passing (was 66/66 before, 1 skipped)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #120)
- [x] Specific improvement addressed: Atoms now display correct CPK element colors

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A, renderer-only change
- [x] If integrator changed: NVE energy conservation tests still pass — N/A
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source

### Testing
- [x] All existing tests pass
- [x] New tests added for new functionality — N/A (rendering fix, not testable without browser)
- [x] Tests would FAIL if the feature were broken — N/A
- [x] Tests are not tautological — N/A

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths — the `useEffect` runs once on mount, not per-frame

### Documentation
- [x] README.md updated if public API/usage changed — N/A
- [x] Complex algorithms have inline comments — added comment explaining the Three.js pitfall

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none needed