### PR TITLE
Impostor rendering for atoms and bonds (#15)

### DIFF
--- a/src/renderer/AtomRenderer.tsx
+++ b/src/renderer/AtomRenderer.tsx
@@ -83,7 +83,7 @@ export const AtomRenderer: React.FC = () => {
       fragmentShader,
       uniforms: {
         uScale: { value: 1.0 },
-        uLightDir: { value: new THREE.Vector3(0.57, 0.57, 0.57) }, // normalized (1,1,1)
+        uLightDir: { value: new THREE.Vector3(0.5774, 0.5774, 0.5774) }, // normalized (1,1,1): 1/sqrt(3)
         uAmbient: { value: new THREE.Vector3(0.25, 0.25, 0.25) },
         uShininess: { value: 40.0 },
       },

--- a/src/renderer/BondRenderer.tsx
+++ b/src/renderer/BondRenderer.tsx
@@ -56,13 +56,19 @@ const _bondMaterial = new THREE.ShaderMaterial({
   vertexShader,
   fragmentShader,
   uniforms: {
-    uBondRadius: { value: 0.08 },
-    uLightDir: { value: new THREE.Vector3(0.57, 0.57, 0.57) },
+    uLightDir: { value: new THREE.Vector3(0.5774, 0.5774, 0.5774) }, // normalized (1,1,1)
     uAmbient: { value: new THREE.Vector3(0.25, 0.25, 0.25) },
   },
   depthTest: true,
   depthWrite: true,
   side: THREE.DoubleSide,
+  // Required for gl_FragDepth to work correctly in the fragment shader
+  extensions: {
+    fragDepth: true,
+    derivatives: false,
+    drawBuffers: false,
+    shaderTextureLOD: false,
+  },
 });
 
 export const BondRenderer: React.FC = () => {
@@ -118,7 +124,6 @@ export const BondRenderer: React.FC = () => {
     }
 
     const bondRadius = renderMode === 'wireframe' ? 0.02 : 0.08;
-    _bondMaterial.uniforms.uBondRadius.value = bondRadius;
 
     let instanceIdx = 0;
 
@@ -208,8 +213,8 @@ export const BondRenderer: React.FC = () => {
 
     mesh.count = instanceIdx;
 
-    // The shader uses aStart/aEnd for positioning, so we still need
-    // instanceMatrix for Three.js — set identity matrices
+    // Mark instanceMatrix as needing update (Three.js requires this even
+    // though our shader reads positions from aStart/aEnd, not instanceMatrix)
     mesh.instanceMatrix.needsUpdate = true;
 
     // Mark instanced attributes as needing update

--- a/src/renderer/shaders/impostor-bond.frag.glsl
+++ b/src/renderer/shaders/impostor-bond.frag.glsl
@@ -1,5 +1,5 @@
 // Impostor cylinder fragment shader
-// Simple Blinn-Phong shaded cylinder using UV-derived normals
+// Blinn-Phong shaded cylinder with correct depth output
 
 uniform vec3 uLightDir;
 uniform vec3 uAmbient;
@@ -15,15 +15,14 @@ varying float vCylinderRadius;
 void main() {
   // vUV.x: -1 to 1 across cylinder width
   // vUV.y: 0 to 1 along bond axis (start to end)
-  
+
   float x = vUV.x;
-  
+
   // Discard outside cylinder silhouette
   if (abs(x) > 1.0) discard;
 
   // For double/triple bonds, check if we're in the gap between cylinders
   if (vBondOrder >= 1.5) {
-    float spacing = 0.6; // cylinder spacing for multiple bonds
     float adjustedX = x * vBondOrder;
     float cylIndex = floor(adjustedX + vBondOrder * 0.5);
     float localX = adjustedX - cylIndex + 0.5;
@@ -34,30 +33,42 @@ void main() {
 
   // Normal from UV (cylinder)
   float z = sqrt(max(0.0, 1.0 - x * x));
-  
+
   // Axis direction in view space
   vec3 axis = normalize(vViewEnd - vViewStart);
   vec3 viewDir = vec3(0.0, 0.0, 1.0);
-  vec3 perp = normalize(cross(axis, viewDir));
-  if (length(perp) < 0.001) {
-    perp = normalize(cross(axis, vec3(0.0, 1.0, 0.0)));
-  }
+
+  // Safe perpendicular: check cross product length before normalizing
+  // to avoid NaN when bond is parallel to view direction
+  vec3 rawPerp = cross(axis, viewDir);
+  vec3 perp = length(rawPerp) > 0.001
+    ? normalize(rawPerp)
+    : normalize(cross(axis, vec3(0.0, 1.0, 0.0)));
   vec3 up = cross(perp, axis);
-  
+
   vec3 normal = normalize(perp * x + up * z);
-  
+
+  // Compute cylinder surface point in view space for correct depth
+  vec3 axisPoint = mix(vViewStart, vViewEnd, vUV.y);
+  vec3 surfacePoint = axisPoint + (perp * x + up * z) * vCylinderRadius;
+
+  // Write correct depth from cylinder surface (not flat quad)
+  vec4 clipPos = projectionMatrix * vec4(surfacePoint, 1.0);
+  float ndcDepth = clipPos.z / clipPos.w;
+  gl_FragDepth = (ndcDepth + 1.0) * 0.5;
+
   // Interpolate color along bond
   float t = vUV.y;
   vec3 color = mix(vColorA, vColorB, t);
-  
-  // Lighting
+
+  // Lighting: Blinn-Phong (shininess 40.0 to match sphere impostor)
   vec3 lightDir = normalize(uLightDir);
   float diff = max(dot(normal, lightDir), 0.0);
-  
+
   vec3 halfDir = normalize(lightDir + viewDir);
-  float spec = pow(max(dot(normal, halfDir), 0.0), 32.0);
-  
+  float spec = pow(max(dot(normal, halfDir), 0.0), 40.0);
+
   vec3 finalColor = uAmbient * color + diff * color + spec * vec3(0.3);
-  
+
   gl_FragColor = vec4(finalColor, 1.0);
 }

--- a/src/renderer/shaders/impostor-bond.vert.glsl
+++ b/src/renderer/shaders/impostor-bond.vert.glsl
@@ -5,7 +5,7 @@ attribute vec3 aStart;   // bond start position (world)
 attribute vec3 aEnd;     // bond end position (world)
 attribute vec3 aColorA;  // color at start
 attribute vec3 aColorB;  // color at end
-attribute float aRadiusA;
+attribute float aRadiusA;  // per-bond cylinder radius
 attribute float aBondOrder; // 1, 2, or 3
 
 varying vec3 vColorA;
@@ -16,19 +16,17 @@ varying vec3 vViewEnd;
 varying float vBondOrder;
 varying float vCylinderRadius;
 
-uniform float uBondRadius; // base cylinder radius
-
 void main() {
   vColorA = aColorA;
   vColorB = aColorB;
   vUV = position.xy; // quad: (-1, 0) to (1, 1)
   vBondOrder = aBondOrder;
-  vCylinderRadius = uBondRadius;
+  vCylinderRadius = aRadiusA;
 
   // Transform endpoints to view space
   vec4 viewStart = modelViewMatrix * vec4(aStart, 1.0);
   vec4 viewEnd = modelViewMatrix * vec4(aEnd, 1.0);
-  
+
   vViewStart = viewStart.xyz;
   vViewEnd = viewEnd.xyz;
 
@@ -36,18 +34,17 @@ void main() {
   vec3 axis = viewEnd.xyz - viewStart.xyz;
   float bondLength = length(axis);
   vec3 dir = axis / max(bondLength, 0.001);
-  
-  // Perpendicular in view space (cross with view direction)
-  vec3 viewDir = vec3(0.0, 0.0, 1.0);
-  vec3 perp = normalize(cross(dir, viewDir));
-  
-  // If bond is parallel to view, use alternate perpendicular
-  if (length(perp) < 0.001) {
-    perp = normalize(cross(dir, vec3(0.0, 1.0, 0.0)));
-  }
 
-  // Expand quad
-  float radius = uBondRadius * 1.5; // extra padding for antialiasing
+  // Perpendicular in view space (cross with view direction)
+  // Check length before normalizing to avoid NaN on parallel bonds
+  vec3 viewDir = vec3(0.0, 0.0, 1.0);
+  vec3 rawPerp = cross(dir, viewDir);
+  vec3 perp = length(rawPerp) > 0.001
+    ? normalize(rawPerp)
+    : normalize(cross(dir, vec3(0.0, 1.0, 0.0)));
+
+  // Expand quad using per-bond radius with padding for antialiasing
+  float radius = aRadiusA * 1.5;
   vec3 pos = mix(viewStart.xyz, viewEnd.xyz, position.y);
   pos += perp * position.x * radius;
   // Push slightly toward camera for depth


### PR DESCRIPTION
Closes #15

## Summary
Switch AtomRenderer and BondRenderer from tessellated geometry (SphereGeometry, CylinderGeometry) to ray-cast impostor shaders. Atoms are rendered as billboard quads with fragment-shader ray-sphere intersection (~2 triangles per atom instead of ~1000 vertices). Bonds use view-aligned quads with fragment-shader cylinder normals. This reduces GPU vertex count by ~100× for large scenes.

## Changes
- **AtomRenderer**: Replaced `SphereGeometry` + `meshStandardMaterial` with billboard quad + `ShaderMaterial` using `impostor-sphere.{vert,frag}.glsl`. Per-instance attributes (`aRadius`, `aColor`, `aSelected`) drive the shader. Module-level pre-allocated buffers avoid GC pressure.
- **BondRenderer**: Replaced `CylinderGeometry` + `meshStandardMaterial` with bond quad + `ShaderMaterial` using `impostor-bond.{vert,frag}.glsl`. One instance per bond (was 2 halves) — the shader handles color interpolation via UV.y. Per-instance attributes (`aStart`, `aEnd`, `aColorA`, `aColorB`, `aRadiusA`, `aBondOrder`) drive the shader.
- Both renderers preserve all existing functionality: render modes (ball-and-stick, space-filling, wireframe), color modes (element, molecule, bondType), selection/hover highlights, weak bond radius scaling, and double/triple bond gap rendering.

## Test Results
- Physics tests: 77/77 passing (was 77/77 before — no regressions)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #15)
- [x] Specific improvement addressed: ~100× vertex count reduction via impostor rendering

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (renderer-only change)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source

### Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality — renderer tests require a browser/WebGL context (out of scope, see issue #48)
- [x] Tests would FAIL if the feature were broken — N/A (renderer-only)
- [x] Tests are not tautological

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths — module-level pre-allocated buffers

### Documentation
- [x] README.md updated if public API/usage changed — N/A (internal renderer change)
- [x] Complex algorithms have inline comments — shader behavior documented in GLSL files

### Follow-ups
- [ ] Follow-up issues created for out-of-scope work discovered during implementation