### PR TITLE
Fix blank 3D scene: add projectionMatrix to fragment shaders (#144)

### DIFF
--- a/src/renderer/AtomRenderer.tsx
+++ b/src/renderer/AtomRenderer.tsx
@@ -92,14 +92,6 @@ export const AtomRenderer: React.FC = () => {
       depthWrite: true,
       // Disable back-face culling since quads face the camera
       side: THREE.DoubleSide,
-      // We write our own depth, so tell Three.js not to use the
-      // default depth from vertex position
-      extensions: {
-        fragDepth: true,
-        derivatives: false,
-        drawBuffers: false,
-        shaderTextureLOD: false,
-      },
     });
   }, []);
 

--- a/src/renderer/BondRenderer.tsx
+++ b/src/renderer/BondRenderer.tsx
@@ -62,13 +62,6 @@ const _bondMaterial = new THREE.ShaderMaterial({
   depthTest: true,
   depthWrite: true,
   side: THREE.DoubleSide,
-  // Required for gl_FragDepth to work correctly in the fragment shader
-  extensions: {
-    fragDepth: true,
-    derivatives: false,
-    drawBuffers: false,
-    shaderTextureLOD: false,
-  },
 });
 
 export const BondRenderer: React.FC = () => {

--- a/src/renderer/shaders/impostor-bond.frag.glsl
+++ b/src/renderer/shaders/impostor-bond.frag.glsl
@@ -1,6 +1,11 @@
 // Impostor cylinder fragment shader
 // Blinn-Phong shaded cylinder with correct depth output
 
+// Three.js injects projectionMatrix into the vertex shader prefix but NOT
+// the fragment shader prefix. We need it here for gl_FragDepth correction,
+// so declare it explicitly.
+uniform mat4 projectionMatrix;
+
 uniform vec3 uLightDir;
 uniform vec3 uAmbient;
 

--- a/src/renderer/shaders/impostor-sphere.frag.glsl
+++ b/src/renderer/shaders/impostor-sphere.frag.glsl
@@ -2,6 +2,11 @@
 // Ray-casts a perfect sphere from a billboarded quad
 // Writes correct depth for proper intersection with other geometry
 
+// Three.js injects projectionMatrix into the vertex shader prefix but NOT
+// the fragment shader prefix. We need it here for gl_FragDepth correction,
+// so declare it explicitly.
+uniform mat4 projectionMatrix;
+
 uniform vec3 uLightDir;
 uniform vec3 uAmbient;
 uniform float uShininess;


### PR DESCRIPTION
Closes #144

## Summary
The impostor sphere and bond fragment shaders use `projectionMatrix` to compute correct `gl_FragDepth` for depth-correct impostor rendering. However, Three.js r183 only injects `projectionMatrix` as a built-in uniform in the **vertex** shader prefix — it is NOT included in the **fragment** shader prefix. This causes a shader compilation error that silently prevents atoms and bonds from rendering, resulting in a blank 3D scene.

## Changes
- Added explicit `uniform mat4 projectionMatrix` declaration to `impostor-sphere.frag.glsl`
- Added explicit `uniform mat4 projectionMatrix` declaration to `impostor-bond.frag.glsl`
- Removed stale `extensions` config (`fragDepth`, `derivatives`, `drawBuffers`, `shaderTextureLOD`) from `AtomRenderer.tsx` and `BondRenderer.tsx` — these properties no longer exist in Three.js r183 `ShaderMaterial` since the features are native in WebGL2

## Test Results
- Physics tests: 100/100 passing (1 skipped known failure)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #144)
- [x] Specific improvement addressed: Fix shader compilation error causing blank 3D scene

### Physics Accuracy
- [x] If force computation changed: gradient test still passes — N/A (no force computation changes)
- [x] If integrator changed: NVE energy conservation tests still pass — N/A (no integrator changes)
- [x] New potential/force has a gradient consistency test — N/A
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source

### Testing
- [x] All existing tests pass
- [x] New tests added for new functionality — N/A (shader bug fix, no testable engine logic)
- [x] Tests would FAIL if the feature were broken — N/A
- [x] Tests are not tautological — N/A

### Performance
- [x] No unnecessary O(N^2) in hot loops
- [x] No per-frame allocations in hot paths

### Documentation
- [x] README.md updated if public API/usage changed — N/A
- [x] Complex algorithms have inline comments — shader declarations include explanatory comment

### Follow-ups
- [x] Follow-up issues created for out-of-scope work discovered during implementation — none needed