### PR TITLE
5.5 Free energy perturbation (#29)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { SimulationPanel } from './SimulationPanel';
 import { ComparisonTable } from './ui/ComparisonTable';
 import { EncounterPanel } from './ui/EncounterPanel';
 import { NEBPanel } from './ui/NEBPanel';
+import { FEPPanel } from './ui/FEPPanel';
 import {
   useSimulationStore,
   createSimulationStoreInstance,
@@ -696,6 +697,7 @@ const App: React.FC = () => {
         <ExperimentPanel />
         <EncounterPanel />
         <NEBPanel />
+        <FEPPanel />
         <ReactionLog />
         <EventLog />
         <QuantityDashboard />

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -461,6 +461,28 @@ export interface WorkerCalmMessage {
   type: 'calm';
 }
 
+/** Configure FEP calculation parameters */
+export interface WorkerFEPConfigMessage {
+  type: 'fep-config';
+  config: FEPConfig;
+}
+
+/** Update the λ parameter for the current FEP calculation */
+export interface WorkerFEPSetLambdaMessage {
+  type: 'fep-set-lambda';
+  lambda: number;
+}
+
+/** Start a full FEP scan across all λ windows */
+export interface WorkerFEPStartScanMessage {
+  type: 'fep-start-scan';
+}
+
+/** Cancel an in-progress FEP scan */
+export interface WorkerFEPCancelMessage {
+  type: 'fep-cancel';
+}
+
 export type WorkerInMessage =
   | WorkerInitMessage
   | WorkerStepMessage
@@ -474,7 +496,11 @@ export type WorkerInMessage =
   | WorkerTransmuteAtomMessage
   | WorkerNEBMessage
   | WorkerNEBCancelMessage
-  | WorkerCalmMessage;
+  | WorkerCalmMessage
+  | WorkerFEPConfigMessage
+  | WorkerFEPSetLambdaMessage
+  | WorkerFEPStartScanMessage
+  | WorkerFEPCancelMessage;
 
 /** Per-force-type potential energy decomposition (all values in eV) */
 export interface EnergyBreakdown {
@@ -544,11 +570,160 @@ export interface WorkerNEBResultMessage {
   result: NEBResult;
 }
 
+/** FEP samples collected during production at one λ window */
+export interface WorkerFEPSamplesMessage {
+  type: 'fep-samples';
+  /** Samples from the most recent production run */
+  samples: FEPSample[];
+}
+
+/** FEP scan progress update */
+export interface WorkerFEPProgressMessage {
+  type: 'fep-progress';
+  progress: FEPProgress;
+}
+
+/** FEP scan complete — final free energy result */
+export interface WorkerFEPResultMessage {
+  type: 'fep-result';
+  result: FEPResult;
+}
+
 export type WorkerOutMessage =
   | WorkerStateUpdate
   | WorkerReadyMessage
   | WorkerNEBProgressMessage
-  | WorkerNEBResultMessage;
+  | WorkerNEBResultMessage
+  | WorkerFEPSamplesMessage
+  | WorkerFEPProgressMessage
+  | WorkerFEPResultMessage;
+
+// --------------- Free Energy Perturbation (FEP) ---------------
+
+/**
+ * Identifies an atom undergoing alchemical transformation between two states.
+ * State A represents the starting system, state B the target system.
+ * During an FEP calculation, the potential V(λ) = (1−λ)·V_A + λ·V_B
+ * smoothly interpolates between the two endpoints.
+ *
+ * Reference: Zwanzig, J. Chem. Phys. 22, 1420 (1954)
+ */
+export interface AlchemicalAtom {
+  /** Atom index in the simulation arrays */
+  atomIndex: number;
+  /** State A (λ=0) properties */
+  stateA: {
+    elementNumber: number;
+    charge: number;
+    hybridization: Hybridization;
+  };
+  /** State B (λ=1) properties */
+  stateB: {
+    elementNumber: number;
+    charge: number;
+    hybridization: Hybridization;
+  };
+}
+
+/**
+ * Configuration for a Free Energy Perturbation calculation.
+ *
+ * Two methods are supported:
+ * - Thermodynamic Integration (TI): ΔG = ∫₀¹ ⟨∂V/∂λ⟩_λ dλ
+ * - FEP (Zwanzig equation): ΔG = −kT ln⟨exp(−ΔV/kT)⟩
+ *
+ * Soft-core potentials (Beutler et al., Chem. Phys. Lett. 222, 529 (1994))
+ * prevent singularities when atoms appear or disappear.
+ */
+export interface FEPConfig {
+  /** Whether FEP is active */
+  enabled: boolean;
+  /** Current λ value [0, 1] — interpolation parameter */
+  lambda: number;
+  /** Atoms undergoing alchemical transformation */
+  alchemicalAtoms: AlchemicalAtom[];
+  /** Soft-core α parameter (default 0.5). Controls the smoothing radius.
+   *  Source: Beutler et al., Chem. Phys. Lett. 222, 529 (1994), Eq. 3 */
+  softCoreAlpha: number;
+  /** Soft-core power p (default 1). Exponent on the λ dependence.
+   *  Source: Beutler et al., Chem. Phys. Lett. 222, 529 (1994), Eq. 3 */
+  softCorePower: number;
+  /** Steps between ∂V/∂λ samples during production (default 1) */
+  collectInterval: number;
+  /** Number of equilibration steps per λ window before collecting samples */
+  equilibrationSteps: number;
+  /** Number of production steps per λ window for collecting samples */
+  productionSteps: number;
+  /** λ values defining the thermodynamic path (e.g. [0.0, 0.1, ..., 1.0]) */
+  lambdaSchedule: number[];
+}
+
+/** Default FEP configuration values */
+export const DEFAULT_FEP_CONFIG: FEPConfig = {
+  enabled: false,
+  lambda: 0,
+  alchemicalAtoms: [],
+  softCoreAlpha: 0.5, // Beutler et al., Chem. Phys. Lett. 222, 529 (1994)
+  softCorePower: 1, // Beutler et al., Chem. Phys. Lett. 222, 529 (1994)
+  collectInterval: 1,
+  equilibrationSteps: 1000,
+  productionSteps: 5000,
+  lambdaSchedule: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+};
+
+/**
+ * A single sample of the FEP thermodynamic estimator collected during
+ * production simulation at a given λ value.
+ */
+export interface FEPSample {
+  /** λ value at which this sample was collected */
+  lambda: number;
+  /** ∂V/∂λ = V_B − V_A at current configuration (eV), used for TI */
+  dVdLambda: number;
+  /** ΔV = V_B − V_A for the Zwanzig exponential average (eV) */
+  deltaV: number;
+  /** Simulation step when this sample was collected */
+  step: number;
+}
+
+/**
+ * Result of a completed FEP/TI free energy calculation.
+ */
+export interface FEPResult {
+  /** Free energy difference ΔG in eV */
+  deltaG: number;
+  /** Statistical error estimate in eV (from block averaging) */
+  error: number;
+  /** Method used: TI (trapezoidal integration) or Zwanzig (exponential average) */
+  method: 'TI' | 'Zwanzig';
+  /** Per-λ-window mean ⟨∂V/∂λ⟩ values (for TI curve plotting) */
+  dVdLambdaMeans: number[];
+  /** Per-λ-window standard errors of ⟨∂V/∂λ⟩ */
+  dVdLambdaErrors: number[];
+  /** λ schedule used */
+  lambdaSchedule: number[];
+}
+
+/** Phases of an FEP scan — tracks progress through the λ schedule */
+export type FEPPhase = 'idle' | 'equilibrating' | 'collecting' | 'complete';
+
+/**
+ * Progress state for an in-flight FEP scan, sent from worker to main thread.
+ */
+export interface FEPProgress {
+  /** Current phase of the FEP calculation */
+  phase: FEPPhase;
+  /** Index into the λ schedule (which window is active) */
+  currentWindowIndex: number;
+  /** Total number of λ windows */
+  totalWindows: number;
+  /** Steps completed in the current window */
+  stepsInWindow: number;
+  /** Total steps for the current window (equil + production) */
+  totalStepsInWindow: number;
+  /** Samples collected so far across all windows */
+  totalSamplesCollected: number;
+}
 
 // --------------- UI State ---------------
 

--- a/src/engine/fep.ts
+++ b/src/engine/fep.ts
@@ -96,6 +96,40 @@ export function blockAverage(values: number[]): [number, number] {
 }
 
 /**
+ * Compute per-window mean ⟨∂V/∂λ⟩ and standard errors from FEP samples.
+ * Shared between computeTI and computeZwanzig.
+ *
+ * @param samples All FEP samples
+ * @param lambdaSchedule Ordered λ values
+ * @returns [means, errors] arrays of length lambdaSchedule.length
+ */
+function computeWindowMeans(
+  samples: FEPSample[],
+  lambdaSchedule: number[],
+): [number[], number[]] {
+  const means: number[] = [];
+  const errors: number[] = [];
+
+  for (let w = 0; w < lambdaSchedule.length; w++) {
+    const lambda = lambdaSchedule[w];
+    const windowSamples = samples
+      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
+      .map((s) => s.dVdLambda);
+
+    if (windowSamples.length === 0) {
+      means.push(0);
+      errors.push(0);
+    } else {
+      const [mean, error] = blockAverage(windowSamples);
+      means.push(mean);
+      errors.push(error);
+    }
+  }
+
+  return [means, errors];
+}
+
+/**
  * Compute the free energy difference using Thermodynamic Integration (TI).
  *
  * ΔG = ∫₀¹ ⟨∂V/∂λ⟩_λ dλ ≈ Σᵢ ½(⟨∂V/∂λ⟩ᵢ + ⟨∂V/∂λ⟩ᵢ₊₁) · (λᵢ₊₁ − λᵢ)
@@ -111,25 +145,12 @@ export function computeTI(
   lambdaSchedule: number[],
 ): FEPResult {
   const nWindows = lambdaSchedule.length;
-  const dVdLambdaMeans: number[] = [];
-  const dVdLambdaErrors: number[] = [];
 
   // Group samples by λ window and compute mean ⟨∂V/∂λ⟩ at each λ
-  for (let w = 0; w < nWindows; w++) {
-    const lambda = lambdaSchedule[w];
-    const windowSamples = samples
-      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
-      .map((s) => s.dVdLambda);
-
-    if (windowSamples.length === 0) {
-      dVdLambdaMeans.push(0);
-      dVdLambdaErrors.push(0);
-    } else {
-      const [mean, error] = blockAverage(windowSamples);
-      dVdLambdaMeans.push(mean);
-      dVdLambdaErrors.push(error);
-    }
-  }
+  const [dVdLambdaMeans, dVdLambdaErrors] = computeWindowMeans(
+    samples,
+    lambdaSchedule,
+  );
 
   // Trapezoidal integration: ΔG = Σ ½(f(λᵢ) + f(λᵢ₊₁)) · Δλ
   let deltaG = 0;
@@ -181,25 +202,12 @@ export function computeZwanzig(
 ): FEPResult {
   const kT = KB * temperature;
   const nWindows = lambdaSchedule.length;
-  const dVdLambdaMeans: number[] = [];
-  const dVdLambdaErrors: number[] = [];
 
-  // We still compute ⟨∂V/∂λ⟩ for the TI curve display
-  for (let w = 0; w < nWindows; w++) {
-    const lambda = lambdaSchedule[w];
-    const windowSamples = samples
-      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
-      .map((s) => s.dVdLambda);
-
-    if (windowSamples.length === 0) {
-      dVdLambdaMeans.push(0);
-      dVdLambdaErrors.push(0);
-    } else {
-      const [mean, error] = blockAverage(windowSamples);
-      dVdLambdaMeans.push(mean);
-      dVdLambdaErrors.push(error);
-    }
-  }
+  // Compute ⟨∂V/∂λ⟩ for the TI curve display
+  const [dVdLambdaMeans, dVdLambdaErrors] = computeWindowMeans(
+    samples,
+    lambdaSchedule,
+  );
 
   // Compute ΔG window-by-window using the exponential average of ΔV
   // For each window at λᵢ, we use the deltaV (= V_B − V_A) samples.

--- a/src/engine/fep.ts
+++ b/src/engine/fep.ts
@@ -1,0 +1,255 @@
+// ==============================================================
+// Free Energy Perturbation (FEP) estimators
+//
+// Two methods for computing free energy differences ΔG:
+//
+// 1. Thermodynamic Integration (TI):
+//    ΔG = ∫₀¹ ⟨∂V/∂λ⟩_λ dλ
+//    Approximated by trapezoidal rule over discrete λ windows.
+//    Reference: Kirkwood, J. Chem. Phys. 3, 300 (1935)
+//
+// 2. Free Energy Perturbation (Zwanzig equation):
+//    ΔG = −kT ln⟨exp(−ΔV/kT)⟩
+//    Reference: Zwanzig, J. Chem. Phys. 22, 1420 (1954)
+//
+// Error estimation uses block averaging:
+//    Reference: Flyvbjerg & Petersen, J. Chem. Phys. 91, 461 (1989)
+// ==============================================================
+
+import type { FEPSample, FEPResult } from '../data/types';
+
+/** Boltzmann constant in eV/K — CODATA 2018 */
+const KB = 8.617333262e-5;
+
+/**
+ * Compute the mean and standard error of an array of values using
+ * block averaging to account for time correlations.
+ *
+ * Block averaging splits the data into blocks of increasing size,
+ * and the standard error plateaus when the block size exceeds the
+ * correlation time. We use the largest block size that still gives
+ * at least 4 blocks (for a meaningful error estimate).
+ *
+ * Reference: Flyvbjerg & Petersen, J. Chem. Phys. 91, 461 (1989)
+ *
+ * @param values Array of sample values
+ * @returns [mean, standardError]
+ */
+export function blockAverage(values: number[]): [number, number] {
+  const n = values.length;
+  if (n === 0) return [0, 0];
+  if (n === 1) return [values[0], 0];
+
+  // Compute overall mean
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    sum += values[i];
+  }
+  const mean = sum / n;
+
+  // Find optimal block size: try block sizes from 1 to n/4,
+  // report the error from the largest block size with ≥ 4 blocks.
+  // Minimum 4 blocks ensures a meaningful variance estimate.
+  const MIN_BLOCKS = 4;
+  let bestError = 0;
+
+  // Start from block size 1 and increase
+  const maxBlockSize = Math.floor(n / MIN_BLOCKS);
+  if (maxBlockSize < 1) {
+    // Not enough data for block averaging; use naive SEM
+    let variance = 0;
+    for (let i = 0; i < n; i++) {
+      const d = values[i] - mean;
+      variance += d * d;
+    }
+    variance /= n - 1;
+    return [mean, Math.sqrt(variance / n)];
+  }
+
+  for (let blockSize = 1; blockSize <= maxBlockSize; blockSize++) {
+    const nBlocks = Math.floor(n / blockSize);
+    if (nBlocks < MIN_BLOCKS) break;
+
+    // Compute block means
+    const blockMeans: number[] = [];
+    for (let b = 0; b < nBlocks; b++) {
+      let blockSum = 0;
+      for (let i = b * blockSize; i < (b + 1) * blockSize; i++) {
+        blockSum += values[i];
+      }
+      blockMeans.push(blockSum / blockSize);
+    }
+
+    // Variance of block means → SEM
+    let blockVariance = 0;
+    for (let b = 0; b < nBlocks; b++) {
+      const d = blockMeans[b] - mean;
+      blockVariance += d * d;
+    }
+    blockVariance /= nBlocks - 1;
+    const sem = Math.sqrt(blockVariance / nBlocks);
+
+    bestError = sem; // keeps updating with largest valid block
+  }
+
+  return [mean, bestError];
+}
+
+/**
+ * Compute the free energy difference using Thermodynamic Integration (TI).
+ *
+ * ΔG = ∫₀¹ ⟨∂V/∂λ⟩_λ dλ ≈ Σᵢ ½(⟨∂V/∂λ⟩ᵢ + ⟨∂V/∂λ⟩ᵢ₊₁) · (λᵢ₊₁ − λᵢ)
+ *
+ * Reference: Kirkwood, J. Chem. Phys. 3, 300 (1935)
+ *
+ * @param samples All FEP samples collected across λ windows
+ * @param lambdaSchedule Ordered λ values used in the calculation
+ * @returns FEPResult with method 'TI'
+ */
+export function computeTI(
+  samples: FEPSample[],
+  lambdaSchedule: number[],
+): FEPResult {
+  const nWindows = lambdaSchedule.length;
+  const dVdLambdaMeans: number[] = [];
+  const dVdLambdaErrors: number[] = [];
+
+  // Group samples by λ window and compute mean ⟨∂V/∂λ⟩ at each λ
+  for (let w = 0; w < nWindows; w++) {
+    const lambda = lambdaSchedule[w];
+    const windowSamples = samples
+      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
+      .map((s) => s.dVdLambda);
+
+    if (windowSamples.length === 0) {
+      dVdLambdaMeans.push(0);
+      dVdLambdaErrors.push(0);
+    } else {
+      const [mean, error] = blockAverage(windowSamples);
+      dVdLambdaMeans.push(mean);
+      dVdLambdaErrors.push(error);
+    }
+  }
+
+  // Trapezoidal integration: ΔG = Σ ½(f(λᵢ) + f(λᵢ₊₁)) · Δλ
+  let deltaG = 0;
+  let errorSquaredSum = 0;
+
+  for (let w = 0; w < nWindows - 1; w++) {
+    const dLambda = lambdaSchedule[w + 1] - lambdaSchedule[w];
+    deltaG += 0.5 * (dVdLambdaMeans[w] + dVdLambdaMeans[w + 1]) * dLambda;
+
+    // Error propagation: σ² ≈ Σ (Δλ/2)² · (σᵢ² + σᵢ₊₁²)
+    const halfDL = 0.5 * dLambda;
+    errorSquaredSum +=
+      halfDL *
+      halfDL *
+      (dVdLambdaErrors[w] * dVdLambdaErrors[w] +
+        dVdLambdaErrors[w + 1] * dVdLambdaErrors[w + 1]);
+  }
+
+  return {
+    deltaG,
+    error: Math.sqrt(errorSquaredSum),
+    method: 'TI',
+    dVdLambdaMeans,
+    dVdLambdaErrors,
+    lambdaSchedule: [...lambdaSchedule],
+  };
+}
+
+/**
+ * Compute the free energy difference using the Zwanzig equation (FEP).
+ *
+ * ΔG = −kT ln⟨exp(−ΔV/kT)⟩
+ *
+ * Uses forward perturbation from each λ window to the next.
+ * Total ΔG is the sum of window-to-window contributions:
+ *   ΔG_total = Σᵢ ΔG(λᵢ → λᵢ₊₁)
+ *
+ * Reference: Zwanzig, J. Chem. Phys. 22, 1420 (1954)
+ *
+ * @param samples All FEP samples collected across λ windows
+ * @param lambdaSchedule Ordered λ values used in the calculation
+ * @param temperature Temperature in K for kT computation
+ * @returns FEPResult with method 'Zwanzig'
+ */
+export function computeZwanzig(
+  samples: FEPSample[],
+  lambdaSchedule: number[],
+  temperature: number,
+): FEPResult {
+  const kT = KB * temperature;
+  const nWindows = lambdaSchedule.length;
+  const dVdLambdaMeans: number[] = [];
+  const dVdLambdaErrors: number[] = [];
+
+  // We still compute ⟨∂V/∂λ⟩ for the TI curve display
+  for (let w = 0; w < nWindows; w++) {
+    const lambda = lambdaSchedule[w];
+    const windowSamples = samples
+      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
+      .map((s) => s.dVdLambda);
+
+    if (windowSamples.length === 0) {
+      dVdLambdaMeans.push(0);
+      dVdLambdaErrors.push(0);
+    } else {
+      const [mean, error] = blockAverage(windowSamples);
+      dVdLambdaMeans.push(mean);
+      dVdLambdaErrors.push(error);
+    }
+  }
+
+  // Compute ΔG window-by-window using the exponential average of ΔV
+  // For each window at λᵢ, we use the deltaV (= V_B − V_A) samples.
+  // The Zwanzig equation for adjacent windows is:
+  //   ΔG(λᵢ→λᵢ₊₁) ≈ −kT·ln⟨exp(−Δλ·(∂V/∂λ)/kT)⟩_λᵢ
+  // where Δλ = λᵢ₊₁ − λᵢ and ∂V/∂λ ≈ deltaV
+  let deltaG = 0;
+  let errorSquaredSum = 0;
+
+  for (let w = 0; w < nWindows - 1; w++) {
+    const lambda = lambdaSchedule[w];
+    const dLambda = lambdaSchedule[w + 1] - lambdaSchedule[w];
+    const windowDeltaV = samples
+      .filter((s) => Math.abs(s.lambda - lambda) < 1e-10)
+      .map((s) => s.deltaV * dLambda);
+
+    if (windowDeltaV.length === 0) continue;
+
+    // Compute ⟨exp(−ΔV/kT)⟩ with numerical stability:
+    // Shift by the mean to prevent overflow/underflow
+    const [meanDV] = blockAverage(windowDeltaV);
+    const beta = 1.0 / kT;
+
+    let expSum = 0;
+    for (let i = 0; i < windowDeltaV.length; i++) {
+      expSum += Math.exp(-beta * (windowDeltaV[i] - meanDV));
+    }
+    const expAvg = expSum / windowDeltaV.length;
+
+    // ΔG for this window = −kT·ln(expAvg) + meanDV
+    // (the meanDV comes from the shift trick)
+    const windowDG = -kT * Math.log(expAvg) + meanDV;
+    deltaG += windowDG;
+
+    // Error estimate: use block averaging on the exponential values
+    const expValues = windowDeltaV.map((dv) => Math.exp(-beta * (dv - meanDV)));
+    const [, expError] = blockAverage(expValues);
+    // Propagate error: σ(ΔG) ≈ kT · σ(⟨exp⟩) / ⟨exp⟩
+    if (expAvg > 1e-30) {
+      const windowError = (kT * expError) / expAvg;
+      errorSquaredSum += windowError * windowError;
+    }
+  }
+
+  return {
+    deltaG,
+    error: Math.sqrt(errorSquaredSum),
+    method: 'Zwanzig',
+    dVdLambdaMeans,
+    dVdLambdaErrors,
+    lambdaSchedule: [...lambdaSchedule],
+  };
+}

--- a/src/engine/forces/softCoreLJ.ts
+++ b/src/engine/forces/softCoreLJ.ts
@@ -1,0 +1,147 @@
+// ==============================================================
+// Soft-core Lennard-Jones potential for alchemical free energy
+// perturbation (FEP) calculations.
+//
+// Avoids the r→0 singularity of standard LJ by replacing r⁶ with
+// a smoothed effective distance:
+//   r_eff⁶ = α·σ⁶·λ^p + r⁶
+//
+// V_sc(r,λ) = 4ε·λⁿ · [ 1/(r_eff⁶/σ⁶)² − 1/(r_eff⁶/σ⁶) ]
+//
+// For linear coupling (n=1) this becomes:
+//   V_sc(r,λ) = 4ε·λ · [ σ¹²/(r_eff⁶)² − σ⁶/r_eff⁶ ]
+//
+// At λ=1, α·σ⁶·1 + r⁶ → σ⁶ + r⁶ ≈ r⁶ for r >> σ^{1/6}·α^{1/6},
+// recovering standard LJ in the physical region.
+// At λ=0, V_sc → 0 smoothly (no singularity).
+//
+// Reference: Beutler et al., Chem. Phys. Lett. 222, 529 (1994), Eq. 3
+// Also: Steinbrecher et al., J. Comput. Chem. 32, 3253 (2011)
+// ==============================================================
+
+import type { Vector3Tuple } from '../../data/types';
+
+/**
+ * Compute soft-core LJ force between two atoms and accumulate into
+ * force arrays. Returns the potential energy contribution (eV) and
+ * the derivative ∂V/∂λ (eV) for thermodynamic integration.
+ *
+ * Uses linear λ-coupling (n=1) as recommended by Steinbrecher et al.
+ *
+ * @param positions flat position array [x0,y0,z0,x1,y1,z1,...]
+ * @param forces    flat force array (accumulated)
+ * @param i         atom index A
+ * @param j         atom index B
+ * @param sigma     LJ sigma (Å)
+ * @param epsilon   LJ epsilon (eV)
+ * @param lambda    coupling parameter [0,1]
+ * @param alpha     soft-core α (dimensionless, typically 0.5)
+ * @param p         soft-core power (typically 1)
+ * @param cutoff    interaction cutoff (Å)
+ * @param boxSize   box dimensions for PBC minimum image (undefined = no PBC)
+ * @returns [energy (eV), dV/dλ (eV)]
+ */
+export function softCoreLJForce(
+  positions: Float64Array,
+  forces: Float64Array,
+  i: number,
+  j: number,
+  sigma: number,
+  epsilon: number,
+  lambda: number,
+  alpha: number,
+  p: number,
+  cutoff: number,
+  boxSize?: Vector3Tuple,
+): [number, number] {
+  const i3 = i * 3;
+  const j3 = j * 3;
+
+  let dx = positions[j3] - positions[i3];
+  let dy = positions[j3 + 1] - positions[i3 + 1];
+  let dz = positions[j3 + 2] - positions[i3 + 2];
+
+  // Apply minimum image convention for periodic boundaries
+  // Reference: Allen & Tildesley, "Computer Simulation of Liquids", Ch. 1.5.2
+  if (boxSize) {
+    dx -= boxSize[0] * Math.round(dx / boxSize[0]);
+    dy -= boxSize[1] * Math.round(dy / boxSize[1]);
+    dz -= boxSize[2] * Math.round(dz / boxSize[2]);
+  }
+
+  const r2 = dx * dx + dy * dy + dz * dz;
+
+  // Cutoff check (use geometric distance, not effective distance)
+  if (r2 > cutoff * cutoff || r2 < 1e-20) return [0, 0];
+
+  // Fully decoupled: no interaction at λ=0
+  if (lambda < 1e-14) return [0, 0];
+
+  const sigma2 = sigma * sigma;
+  const sigma6 = sigma2 * sigma2 * sigma2;
+  const r6 = r2 * r2 * r2;
+
+  // Effective distance: r_eff⁶ = α·σ⁶·λ^p + r⁶
+  // Reference: Beutler et al., Chem. Phys. Lett. 222, 529 (1994), Eq. 3
+  const lambdaP = p === 1 ? lambda : Math.pow(lambda, p);
+  const rEff6 = alpha * sigma6 * lambdaP + r6;
+
+  // Avoid division by extremely small values
+  if (rEff6 < 1e-30) return [0, 0];
+
+  // Dimensionless ratios: s = σ⁶/r_eff⁶
+  const s = sigma6 / rEff6;
+  const s2 = s * s;
+
+  // Energy: V = 4ε·λ·(s² − s) = 4ε·λ·s·(s − 1)
+  const energy = 4.0 * epsilon * lambda * (s2 - s);
+
+  // --- Force: F = −∂V/∂r · (r_vec/r) ---
+  // ∂V/∂r = 4ε·λ · (2s² − s) · (−6r⁵/r_eff⁶) · (1/r)
+  //        = −24ε·λ·r⁴/r_eff⁶ · (2s² − s)
+  // But: ∂V/∂(r²) = ∂V/∂r · 1/(2r), so we compute ∂V/∂(r²) instead
+  // and multiply by displacement vector.
+  //
+  // ∂(r_eff⁶)/∂(r²) = 3r⁴ = 3·(r²)²
+  // ∂s/∂(r²) = −σ⁶/(r_eff⁶)² · 3r⁴ = −s/r_eff⁶ · 3r⁴
+  // ∂V/∂(r²) = 4ε·λ·(2s−1)·∂s/∂(r²)
+  //           = 4ε·λ·(2s−1)·(−3·s·r⁴/r_eff⁶)
+  //           = −12ε·λ·s·(2s−1)·r⁴/r_eff⁶
+  //
+  // F_x = −∂V/∂x = −∂V/∂(r²) · 2·dx
+  //      = 24ε·λ·s·(2s−1)·r⁴/(r_eff⁶) · dx
+  const r4 = r2 * r2;
+  const fPrefactor =
+    (24.0 * epsilon * lambda * s * (2.0 * s - 1.0) * r4) / rEff6;
+
+  const fx = fPrefactor * dx;
+  const fy = fPrefactor * dy;
+  const fz = fPrefactor * dz;
+
+  // Newton's third law
+  forces[i3] -= fx;
+  forces[i3 + 1] -= fy;
+  forces[i3 + 2] -= fz;
+  forces[j3] += fx;
+  forces[j3 + 1] += fy;
+  forces[j3 + 2] += fz;
+
+  // --- ∂V/∂λ for thermodynamic integration ---
+  // V = 4ε·λ·(s² − s), where s = σ⁶/r_eff⁶ and r_eff⁶ = α·σ⁶·λ^p + r⁶
+  //
+  // ∂V/∂λ = 4ε·(s² − s) + 4ε·λ·∂(s² − s)/∂λ
+  //
+  // ∂s/∂λ = −σ⁶·α·σ⁶·p·λ^(p-1)/(r_eff⁶)²
+  //        = −s · α·σ⁶·p·λ^(p-1) / r_eff⁶
+  //
+  // ∂(s²−s)/∂λ = (2s−1)·∂s/∂λ
+  //
+  // ∂V/∂λ = 4ε·(s²−s) + 4ε·λ·(2s−1)·∂s/∂λ
+  const dLambdaP = p === 1 ? 1.0 : p * Math.pow(lambda, p - 1);
+  const dsdLambda = (-s * alpha * sigma6 * dLambdaP) / rEff6;
+  const dVdLambda =
+    4.0 * epsilon * (s2 - s) +
+    4.0 * epsilon * lambda * (2.0 * s - 1.0) * dsdLambda;
+
+  return [energy, dVdLambda];
+}

--- a/src/engine/tests.ts
+++ b/src/engine/tests.ts
@@ -89,6 +89,9 @@ import {
   DEFAULT_NEB_CONFIG,
 } from './neb';
 import { steepestDescent } from './minimizer';
+import { softCoreLJForce } from './forces/softCoreLJ';
+import { blockAverage, computeTI, computeZwanzig } from './fep';
+import type { FEPSample } from '../data/types';
 
 // ---- Deterministic PRNG for reproducible tests ----
 // Mulberry32: a simple 32-bit seeded PRNG (public domain)
@@ -3972,6 +3975,438 @@ function runAngularMomentumTests(): void {
   }
 }
 
+// ==============================================================
+// Free Energy Perturbation Tests
+// ==============================================================
+
+function runFEPTests(): void {
+  console.log('\n--- Free Energy Perturbation Tests ---');
+
+  // FEP-01: Soft-core LJ is singularity-free at r→0
+  {
+    const id = 'FEP-01';
+    if (!isSkipped(id)) {
+      // At very small r with λ < 1, soft-core should NOT blow up
+      const positions = new Float64Array([0, 0, 0, 0.01, 0, 0]); // r = 0.01 Å
+      const forces = new Float64Array(6);
+      const sigma = 3.4; // Å (typical LJ σ for Ar)
+      const epsilon = 0.0104; // eV (typical LJ ε for Ar)
+      // Source: Rahman, Phys. Rev. 136, A405 (1964) — Ar LJ params
+
+      const [energy, dVdL] = softCoreLJForce(
+        positions,
+        forces,
+        0,
+        1,
+        sigma,
+        epsilon,
+        0.5, // λ = 0.5
+        0.5, // α = 0.5
+        1, // p = 1
+        10.0,
+      );
+
+      const isFinite =
+        Number.isFinite(energy) &&
+        Number.isFinite(dVdL) &&
+        Number.isFinite(forces[0]) &&
+        Number.isFinite(forces[3]);
+      const isReasonable = Math.abs(energy) < 100; // should be small, not 1e30
+
+      const passed = isFinite && isReasonable;
+      report(
+        id,
+        'Soft-core LJ is singularity-free at r=0.01 Å, λ=0.5',
+        passed,
+        `E=${energy.toFixed(6)} eV, dV/dλ=${dVdL.toFixed(6)} eV, |F|=${Math.abs(forces[0]).toFixed(6)} eV/Å`,
+        'All values finite, |E| < 100 eV',
+      );
+    }
+  }
+
+  // FEP-02: Soft-core reduces to standard LJ at λ=1 for large r
+  {
+    const id = 'FEP-02';
+    if (!isSkipped(id)) {
+      const r = 4.0; // Å — well beyond the singularity region
+      const positions = new Float64Array([0, 0, 0, r, 0, 0]);
+      const forcesSC = new Float64Array(6);
+      const forcesStd = new Float64Array(6);
+      const sigma = 3.4; // Å — Ar LJ (Rahman, Phys. Rev. 136, A405 (1964))
+      const epsilon = 0.0104; // eV — Ar LJ
+
+      const [energySC] = softCoreLJForce(
+        positions,
+        forcesSC,
+        0,
+        1,
+        sigma,
+        epsilon,
+        1.0, // λ = 1
+        0.5,
+        1,
+        10.0,
+      );
+      const energyStd = ljForce(
+        positions,
+        forcesStd,
+        0,
+        1,
+        sigma,
+        epsilon,
+        10.0,
+      );
+
+      // At λ=1, soft-core has r_eff⁶ = α·σ⁶ + r⁶
+      // For r ≈ σ, this is NOT exactly standard LJ (the α term adds).
+      // But for r >> σ, the α·σ⁶ term becomes negligible.
+      // At r = 4.0 Å and σ = 3.4 Å: r⁶ = 4096, α·σ⁶ ≈ 0.5·1544 ≈ 772
+      // So r_eff⁶ ≈ 4868 vs r⁶ = 4096 → ~19% difference at r/σ ≈ 1.18
+      // Use a looser tolerance that accounts for the soft-core correction
+      const relErr =
+        Math.abs(energyStd) > 1e-15
+          ? Math.abs(energySC - energyStd) / Math.abs(energyStd)
+          : Math.abs(energySC - energyStd);
+
+      // At this r/σ ratio, allow up to 50% relative error due to soft-core
+      const passed = relErr < 0.5;
+      report(
+        id,
+        'Soft-core approximates standard LJ at λ=1, r=4.0 Å',
+        passed,
+        `E_sc=${energySC.toExponential(4)}, E_std=${energyStd.toExponential(4)}, relErr=${relErr.toExponential(3)}`,
+        'Relative error < 50% (soft-core α correction expected)',
+      );
+    }
+  }
+
+  // FEP-03: Soft-core energy is zero at λ=0
+  {
+    const id = 'FEP-03';
+    if (!isSkipped(id)) {
+      const positions = new Float64Array([0, 0, 0, 2.0, 0, 0]);
+      const forces = new Float64Array(6);
+      const sigma = 3.4; // Å — Ar LJ
+      const epsilon = 0.0104; // eV — Ar LJ
+
+      const [energy] = softCoreLJForce(
+        positions,
+        forces,
+        0,
+        1,
+        sigma,
+        epsilon,
+        0.0, // λ = 0
+        0.5,
+        1,
+        10.0,
+      );
+
+      const passed =
+        Math.abs(energy) < 1e-14 &&
+        Math.abs(forces[0]) < 1e-14 &&
+        Math.abs(forces[3]) < 1e-14;
+      report(
+        id,
+        'Soft-core LJ energy and forces are zero at λ=0',
+        passed,
+        `E=${energy.toExponential(3)}, F0=${forces[0].toExponential(3)}`,
+        '|E| < 1e-14, |F| < 1e-14',
+      );
+    }
+  }
+
+  // FEP-04: Gradient consistency of soft-core potential
+  {
+    const id = 'FEP-04';
+    if (!isSkipped(id)) {
+      // Numerical gradient: F_x ≈ −[V(x+h) − V(x−h)] / (2h)
+      const r0 = 3.0;
+      const h = 1e-5;
+      const sigma = 3.4; // Å — Ar LJ
+      const epsilon = 0.0104; // eV — Ar LJ
+      const lambda = 0.6;
+
+      // V(x + h)
+      const posFwd = new Float64Array([0, 0, 0, r0 + h, 0, 0]);
+      const frcFwd = new Float64Array(6);
+      const [eFwd] = softCoreLJForce(
+        posFwd,
+        frcFwd,
+        0,
+        1,
+        sigma,
+        epsilon,
+        lambda,
+        0.5,
+        1,
+        10.0,
+      );
+
+      // V(x - h)
+      const posBwd = new Float64Array([0, 0, 0, r0 - h, 0, 0]);
+      const frcBwd = new Float64Array(6);
+      const [eBwd] = softCoreLJForce(
+        posBwd,
+        frcBwd,
+        0,
+        1,
+        sigma,
+        epsilon,
+        lambda,
+        0.5,
+        1,
+        10.0,
+      );
+
+      // Analytical force at r0
+      const posCenter = new Float64Array([0, 0, 0, r0, 0, 0]);
+      const frcCenter = new Float64Array(6);
+      softCoreLJForce(
+        posCenter,
+        frcCenter,
+        0,
+        1,
+        sigma,
+        epsilon,
+        lambda,
+        0.5,
+        1,
+        10.0,
+      );
+
+      // F_j(x) = +fPrefactor * dx, and F_i(x) = -fPrefactor * dx
+      // So the force on atom j in the +x direction is frcCenter[3]
+      const numericalGrad = -(eFwd - eBwd) / (2 * h);
+      const analyticalForce = frcCenter[3]; // force on j in x
+
+      const relErr =
+        Math.abs(analyticalForce) > 1e-15
+          ? Math.abs(numericalGrad - analyticalForce) /
+            Math.abs(analyticalForce)
+          : Math.abs(numericalGrad - analyticalForce);
+
+      const passed = relErr < 1e-4;
+      report(
+        id,
+        'Soft-core LJ gradient consistency (numerical vs analytical)',
+        passed,
+        `F_num=${numericalGrad.toExponential(6)}, F_ana=${analyticalForce.toExponential(6)}, relErr=${relErr.toExponential(3)}`,
+        'Relative error < 1e-4',
+      );
+    }
+  }
+
+  // FEP-05: TI on a known analytical integral
+  {
+    const id = 'FEP-05';
+    if (!isSkipped(id)) {
+      // If ∂V/∂λ = constant c at all λ, then ΔG = ∫₀¹ c dλ = c
+      // Use c = 2.5 eV
+      const c = 2.5;
+      const lambdaSchedule = [0.0, 0.25, 0.5, 0.75, 1.0];
+      const samples: FEPSample[] = [];
+
+      // Generate 100 samples per window with the constant value
+      for (const lam of lambdaSchedule) {
+        for (let i = 0; i < 100; i++) {
+          samples.push({
+            lambda: lam,
+            dVdLambda: c,
+            deltaV: c,
+            step: i,
+          });
+        }
+      }
+
+      const result = computeTI(samples, lambdaSchedule);
+      const relErr = Math.abs(result.deltaG - c) / c;
+
+      const passed = relErr < 1e-10;
+      report(
+        id,
+        'TI recovers exact integral of constant ∂V/∂λ = 2.5 eV',
+        passed,
+        `ΔG=${result.deltaG.toFixed(6)} eV, expected=${c.toFixed(6)} eV, relErr=${relErr.toExponential(3)}`,
+        'Relative error < 1e-10',
+      );
+    }
+  }
+
+  // FEP-06: TI on a linear ∂V/∂λ = λ (integral = 0.5)
+  {
+    const id = 'FEP-06';
+    if (!isSkipped(id)) {
+      // ∂V/∂λ = λ → ΔG = ∫₀¹ λ dλ = 0.5
+      const lambdaSchedule = [
+        0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+      ];
+      const samples: FEPSample[] = [];
+
+      for (const lam of lambdaSchedule) {
+        for (let i = 0; i < 100; i++) {
+          samples.push({
+            lambda: lam,
+            dVdLambda: lam, // ∂V/∂λ = λ
+            deltaV: lam,
+            step: i,
+          });
+        }
+      }
+
+      const result = computeTI(samples, lambdaSchedule);
+      const expected = 0.5;
+      const relErr = Math.abs(result.deltaG - expected) / expected;
+
+      const passed = relErr < 1e-10;
+      report(
+        id,
+        'TI recovers ΔG=0.5 for linear ∂V/∂λ = λ',
+        passed,
+        `ΔG=${result.deltaG.toFixed(6)} eV, expected=${expected.toFixed(6)} eV, relErr=${relErr.toExponential(3)}`,
+        'Relative error < 1e-10 (trapezoidal rule is exact for linear functions)',
+      );
+    }
+  }
+
+  // FEP-07: Zwanzig on known ΔG (constant energy difference)
+  {
+    const id = 'FEP-07';
+    if (!isSkipped(id)) {
+      // If ΔV = constant c at all λ windows, then
+      // ΔG = −kT·ln⟨exp(−c·Δλ/kT)⟩ summed over windows = c
+      // Because ⟨exp(−c·Δλ/kT)⟩ = exp(−c·Δλ/kT) when ΔV is deterministic
+      const c = 1.0; // eV
+      const T = 300; // K
+      const lambdaSchedule = [0.0, 0.25, 0.5, 0.75, 1.0];
+      const samples: FEPSample[] = [];
+
+      for (const lam of lambdaSchedule) {
+        for (let i = 0; i < 200; i++) {
+          samples.push({
+            lambda: lam,
+            dVdLambda: c,
+            deltaV: c, // V_B − V_A = c at every configuration
+            step: i,
+          });
+        }
+      }
+
+      const result = computeZwanzig(samples, lambdaSchedule, T);
+      const relErr = Math.abs(result.deltaG - c) / c;
+
+      const passed = relErr < 1e-6;
+      report(
+        id,
+        'Zwanzig recovers ΔG=1.0 eV for constant ΔV',
+        passed,
+        `ΔG=${result.deltaG.toFixed(6)} eV, expected=${c.toFixed(6)} eV, relErr=${relErr.toExponential(3)}`,
+        'Relative error < 1e-6',
+      );
+    }
+  }
+
+  // FEP-08: Block averaging on uncorrelated data matches naive SEM
+  {
+    const id = 'FEP-08';
+    if (!isSkipped(id)) {
+      // For uncorrelated data, block averaging should give
+      // approximately the same SEM as the naive formula.
+      const n = 1000;
+      const values: number[] = [];
+      // Use the seeded PRNG for reproducibility
+      for (let i = 0; i < n; i++) {
+        // Box-Muller transform for approximate normal distribution
+        const u1 = seededRng();
+        const u2 = seededRng();
+        values.push(
+          5.0 + 2.0 * Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2),
+        );
+      }
+
+      const [mean, blockError] = blockAverage(values);
+
+      // Naive SEM = σ / √n
+      let variance = 0;
+      for (let i = 0; i < n; i++) {
+        const d = values[i] - mean;
+        variance += d * d;
+      }
+      variance /= n - 1;
+      const naiveSEM = Math.sqrt(variance / n);
+
+      // Block error should be within 2x of naive SEM for uncorrelated data
+      const ratio = blockError / naiveSEM;
+      const passed = ratio > 0.3 && ratio < 3.0 && Math.abs(mean - 5.0) < 0.5;
+
+      report(
+        id,
+        'Block averaging on uncorrelated data ≈ naive SEM',
+        passed,
+        `mean=${mean.toFixed(3)}, blockErr=${blockError.toExponential(3)}, naiveSEM=${naiveSEM.toExponential(3)}, ratio=${ratio.toFixed(3)}`,
+        '0.3 < ratio < 3.0, |mean - 5.0| < 0.5',
+      );
+    }
+  }
+
+  // FEP-09: Soft-core dV/dλ is smooth (no discontinuities)
+  {
+    const id = 'FEP-09';
+    if (!isSkipped(id)) {
+      // Sample dV/dλ at many λ values and check it's smooth
+      const r = 2.5; // Å — well inside the cutoff
+      const sigma = 3.4; // Å — Ar LJ
+      const epsilon = 0.0104; // eV — Ar LJ
+      const nPoints = 20;
+      const dVdLambdaValues: number[] = [];
+
+      for (let i = 0; i <= nPoints; i++) {
+        const lambda = i / nPoints;
+        const pos = new Float64Array([0, 0, 0, r, 0, 0]);
+        const frc = new Float64Array(6);
+        const [, dVdL] = softCoreLJForce(
+          pos,
+          frc,
+          0,
+          1,
+          sigma,
+          epsilon,
+          Math.max(lambda, 1e-14), // avoid exact 0
+          0.5,
+          1,
+          10.0,
+        );
+        dVdLambdaValues.push(dVdL);
+      }
+
+      // Check all values are finite
+      const allFinite = dVdLambdaValues.every((v) => Number.isFinite(v));
+
+      // Check smoothness: no consecutive pair should differ by more than 10x
+      // the average step difference (allowing for curvature)
+      let maxJump = 0;
+      let avgStep = 0;
+      for (let i = 1; i < dVdLambdaValues.length; i++) {
+        const jump = Math.abs(dVdLambdaValues[i] - dVdLambdaValues[i - 1]);
+        maxJump = Math.max(maxJump, jump);
+        avgStep += jump;
+      }
+      avgStep /= dVdLambdaValues.length - 1;
+
+      // Max jump should not be more than 20x the average step
+      // (generous to allow for rapid but continuous variation)
+      const passed = allFinite && (avgStep < 1e-15 || maxJump / avgStep < 20);
+      report(
+        id,
+        'Soft-core dV/dλ is smooth across λ=[0,1]',
+        passed,
+        `allFinite=${allFinite}, maxJump=${maxJump.toExponential(3)}, avgStep=${avgStep.toExponential(3)}`,
+        'All values finite, max jump < 20× average step',
+      );
+    }
+  }
+}
+
 // ---- Main ----
 
 console.log('╔══════════════════════════════════════════════════╗');
@@ -3993,6 +4428,7 @@ runBondPlacementTests();
 runCrystalBuilderTests();
 runNEBTests();
 runAngularMomentumTests();
+runFEPTests();
 
 // Summary
 console.log('\n' + '='.repeat(50));

--- a/src/engine/tests.ts
+++ b/src/engine/tests.ts
@@ -4028,7 +4028,7 @@ function runFEPTests(): void {
   {
     const id = 'FEP-02';
     if (!isSkipped(id)) {
-      const r = 4.0; // Å — well beyond the singularity region
+      const r = 5.0; // Å — well beyond σ so soft-core α term is small
       const positions = new Float64Array([0, 0, 0, r, 0, 0]);
       const forcesSC = new Float64Array(6);
       const forcesStd = new Float64Array(6);
@@ -4058,24 +4058,22 @@ function runFEPTests(): void {
       );
 
       // At λ=1, soft-core has r_eff⁶ = α·σ⁶ + r⁶
-      // For r ≈ σ, this is NOT exactly standard LJ (the α term adds).
-      // But for r >> σ, the α·σ⁶ term becomes negligible.
-      // At r = 4.0 Å and σ = 3.4 Å: r⁶ = 4096, α·σ⁶ ≈ 0.5·1544 ≈ 772
-      // So r_eff⁶ ≈ 4868 vs r⁶ = 4096 → ~19% difference at r/σ ≈ 1.18
-      // Use a looser tolerance that accounts for the soft-core correction
+      // For r >> σ, the α·σ⁶ term becomes negligible.
+      // At r = 5.0 Å and σ = 3.4 Å: r⁶ = 15625, α·σ⁶ ≈ 0.5·1544 ≈ 772
+      // So r_eff⁶ ≈ 16397 vs r⁶ = 15625 → ~5% difference
       const relErr =
         Math.abs(energyStd) > 1e-15
           ? Math.abs(energySC - energyStd) / Math.abs(energyStd)
           : Math.abs(energySC - energyStd);
 
-      // At this r/σ ratio, allow up to 50% relative error due to soft-core
-      const passed = relErr < 0.5;
+      // At r/σ ≈ 1.47, soft-core correction is small; allow 15%
+      const passed = relErr < 0.15;
       report(
         id,
-        'Soft-core approximates standard LJ at λ=1, r=4.0 Å',
+        'Soft-core approximates standard LJ at λ=1, r=5.0 Å',
         passed,
         `E_sc=${energySC.toExponential(4)}, E_std=${energyStd.toExponential(4)}, relErr=${relErr.toExponential(3)}`,
-        'Relative error < 50% (soft-core α correction expected)',
+        'Relative error < 15% (soft-core α correction small at r/σ ≈ 1.47)',
       );
     }
   }

--- a/src/engine/worker.ts
+++ b/src/engine/worker.ts
@@ -916,30 +916,20 @@ function computeAllForces(pos: Float64Array, frc: Float64Array): number {
         coulombE += eCoul;
         potentialEnergy += eCoul;
 
-        // ∂V_coul/∂λ: compute Coulomb at state A and state B params
-        // and take the difference for the derivative
-        const frcDummy = new Float64Array(frc.length);
-        const eCoulA = coulombForce(
-          pos,
-          frcDummy,
-          i,
-          j,
-          qiA,
-          qjA,
-          wc,
-          pbcBoxSize,
-        );
-        const eCoulB = coulombForce(
-          pos,
-          frcDummy,
-          i,
-          j,
-          qiB,
-          qjB,
-          wc,
-          pbcBoxSize,
-        );
-        dVdLambdaTotal += eCoulB - eCoulA;
+        // ∂V_coul/∂λ for Coulomb with bilinear charge interpolation:
+        // V = f(r) · qi(λ) · qj(λ) where qi = (1-λ)qiA + λqiB
+        // ∂V/∂λ = f(r) · [(qiB-qiA)·qj(λ) + qi(λ)·(qjB-qjA)]
+        // Since V = f(r)·qi·qj, we have f(r) = V/(qi·qj) when qi·qj ≠ 0.
+        // Alternatively, compute two Coulomb evaluations for the derivative
+        // terms directly using the charge derivatives.
+        const dqiDl = qiB - qiA;
+        const dqjDl = qjB - qjA;
+        if (Math.abs(qi * qj) > 1e-30 && Math.abs(eCoul) > 1e-30) {
+          // f(r) = eCoul / (qi * qj), so:
+          // ∂V/∂λ = (eCoul / (qi*qj)) * (dqi*qj + qi*dqj)
+          const fr = eCoul / (qi * qj);
+          dVdLambdaTotal += fr * (dqiDl * qj + qi * dqjDl);
+        }
       } else {
         // Standard (non-alchemical) pair
         const { sigma, epsilon } = getLJCached(
@@ -1719,7 +1709,7 @@ function runFEPScan(): void {
               windowSamples.push({
                 lambda: currentLambda,
                 dVdLambda: cachedDVDLambda,
-                deltaV: cachedDVDLambda, // For single-topology, ΔV ≈ ∂V/∂λ
+                deltaV: cachedDVDLambda, // Single-topology approximation: ΔV ≈ ∂V/∂λ · Δλ (first-order Taylor; the Zwanzig estimator applies Δλ scaling per window)
                 step,
               });
             }

--- a/src/engine/worker.ts
+++ b/src/engine/worker.ts
@@ -6,6 +6,9 @@ import type {
   Atom,
   Bond,
   EnergyBreakdown,
+  FEPConfig,
+  FEPProgress,
+  FEPSample,
   Hybridization,
   MoleculeInfo,
   NEBConfig,
@@ -50,6 +53,9 @@ import {
 } from './thermostat';
 import type { NoseHooverChainState } from './thermostat';
 import { steepestDescent } from './minimizer';
+import { softCoreLJForce } from './forces/softCoreLJ';
+import { computeTI, computeZwanzig } from './fep';
+import { DEFAULT_FEP_CONFIG } from '../data/types';
 import { runNEB } from './neb';
 import {
   detectBonds,
@@ -278,6 +284,33 @@ let hasPrevTopology = false;
 /** Reaction events detected in the most recent topology rebuild */
 let pendingReactionEvents: ReactionEvent[] = [];
 
+// ---- FEP (Free Energy Perturbation) state ----
+let fepConfig: FEPConfig = { ...DEFAULT_FEP_CONFIG };
+/** Set of atom indices undergoing alchemical transformation */
+const fepAlchemicalSet: Set<number> = new Set();
+/** State B bond parameters for alchemical atoms (indexed same as bondParams) */
+let bondParamsB: Array<{
+  i: number;
+  j: number;
+  De: number;
+  alpha: number;
+  re: number;
+}> = [];
+/** Whether each bond in bondParams involves an alchemical atom */
+let bondIsAlchemical: boolean[] = [];
+/** State B charges for alchemical atoms */
+let chargesB: Float64Array = new Float64Array(0);
+/** State B atomic numbers for alchemical atoms (others = 0) */
+let atomicNumbersB: Int32Array = new Int32Array(0);
+/** Accumulated FEP samples during a scan */
+let fepSamples: FEPSample[] = [];
+/** Whether an FEP scan is currently running */
+let fepScanActive = false;
+/** Whether the FEP scan has been cancelled */
+let fepScanCancelled = false;
+/** Accumulated dV/dλ for the current step (set during computeAllForces) */
+let cachedDVDLambda = 0;
+
 // ---- Force field parameter setup ----
 function rebuildTopology(): void {
   // Snapshot previous topology for reaction detection
@@ -384,6 +417,12 @@ function rebuildTopology(): void {
       charges[i] = gasteigerQ[i];
     }
   }
+
+  // --- FEP: Build state B parameters for alchemical atoms ---
+  // When FEP is active, we need a parallel set of force field parameters
+  // computed with state B element numbers/hybridizations for each alchemical atom.
+  // Non-alchemical interactions use state A parameters only.
+  rebuildFEPParams();
 
   // Rebuild cell list
   if (!cellList) {
@@ -534,6 +573,75 @@ function buildTorsionParams(): void {
   gpuDataDirty = true;
 }
 
+/**
+ * Rebuild FEP state B parameters when FEP is active.
+ * Computes state B Morse bond params and charges for alchemical atoms,
+ * so that computeAllForces() can interpolate between A and B.
+ */
+function rebuildFEPParams(): void {
+  // Build the set of alchemical atom indices for O(1) lookup
+  fepAlchemicalSet.clear();
+  bondParamsB = [];
+  bondIsAlchemical = [];
+  chargesB = new Float64Array(nAtoms);
+  atomicNumbersB = new Int32Array(nAtoms);
+
+  if (!fepConfig.enabled || fepConfig.alchemicalAtoms.length === 0) {
+    return;
+  }
+
+  // Map: atomIndex → stateB properties
+  const stateB = new Map<
+    number,
+    { elementNumber: number; charge: number; hybridization: Hybridization }
+  >();
+  for (const aa of fepConfig.alchemicalAtoms) {
+    fepAlchemicalSet.add(aa.atomIndex);
+    stateB.set(aa.atomIndex, aa.stateB);
+    atomicNumbersB[aa.atomIndex] = aa.stateB.elementNumber;
+    chargesB[aa.atomIndex] = aa.stateB.charge;
+  }
+
+  // Copy non-alchemical atom charges/numbers to B (they are the same as A)
+  for (let i = 0; i < nAtoms; i++) {
+    if (!fepAlchemicalSet.has(i)) {
+      chargesB[i] = charges[i];
+      atomicNumbersB[i] = atomicNumbers[i];
+    }
+  }
+
+  // Build state B bond parameters for each bond in bondParams
+  for (const bp of bondParams) {
+    const aIsAlch = fepAlchemicalSet.has(bp.i);
+    const bIsAlch = fepAlchemicalSet.has(bp.j);
+    const isAlch = aIsAlch || bIsAlch;
+    bondIsAlchemical.push(isAlch);
+
+    if (isAlch) {
+      // Get state B element numbers
+      const zA = aIsAlch
+        ? stateB.get(bp.i)!.elementNumber
+        : atomicNumbers[bp.i];
+      const zB = bIsAlch
+        ? stateB.get(bp.j)!.elementNumber
+        : atomicNumbers[bp.j];
+      const hybA = aIsAlch
+        ? stateB.get(bp.i)!.hybridization
+        : hybridizations[bp.i];
+      const hybB = bIsAlch
+        ? stateB.get(bp.j)!.hybridization
+        : hybridizations[bp.j];
+
+      // Compute state B Morse parameters with the new element numbers
+      const paramsB = getMorseBondParams(zA, zB, 1, hybA, hybB);
+      bondParamsB.push({ i: bp.i, j: bp.j, ...paramsB });
+    } else {
+      // Same as state A
+      bondParamsB.push({ ...bp });
+    }
+  }
+}
+
 function getLJCached(
   z1: number,
   z2: number,
@@ -574,25 +682,77 @@ function computeAllForces(pos: Float64Array, frc: Float64Array): number {
   let inversionE = 0;
   let ljE = 0;
   let coulombE = 0;
+  let dVdLambdaTotal = 0;
 
   // PBC minimum image box size — used for both bonded and non-bonded forces.
   // Reference: Allen & Tildesley, "Computer Simulation of Liquids", Ch. 1.5.2
   const pbcBoxSize = box.periodic ? box.size : undefined;
 
-  // 1. Bonded forces (Morse)
-  for (const bp of bondParams) {
-    const e = morseBondForce(
-      pos,
-      frc,
-      bp.i,
-      bp.j,
-      bp.De,
-      bp.alpha,
-      bp.re,
-      pbcBoxSize,
-    );
-    morseE += e;
-    potentialEnergy += e;
+  // FEP parameters
+  const fepActive = fepConfig.enabled && fepAlchemicalSet.size > 0;
+  const lambda = fepConfig.lambda;
+
+  // 1. Bonded forces (Morse) — with FEP λ-interpolation for alchemical bonds
+  for (let bi = 0; bi < bondParams.length; bi++) {
+    const bp = bondParams[bi];
+
+    if (fepActive && bondIsAlchemical[bi]) {
+      // Alchemical bond: V(λ) = (1−λ)·V_A + λ·V_B
+      // Use temporary force arrays to compute A and B separately
+      const frcA = new Float64Array(frc.length);
+      const frcB = new Float64Array(frc.length);
+      const bpB = bondParamsB[bi];
+
+      const eA = morseBondForce(
+        pos,
+        frcA,
+        bp.i,
+        bp.j,
+        bp.De,
+        bp.alpha,
+        bp.re,
+        pbcBoxSize,
+      );
+      const eB = morseBondForce(
+        pos,
+        frcB,
+        bpB.i,
+        bpB.j,
+        bpB.De,
+        bpB.alpha,
+        bpB.re,
+        pbcBoxSize,
+      );
+
+      // Interpolated energy and forces
+      const e = (1 - lambda) * eA + lambda * eB;
+      const i3A = bp.i * 3;
+      const j3A = bp.j * 3;
+      frc[i3A] += (1 - lambda) * frcA[i3A] + lambda * frcB[i3A];
+      frc[i3A + 1] += (1 - lambda) * frcA[i3A + 1] + lambda * frcB[i3A + 1];
+      frc[i3A + 2] += (1 - lambda) * frcA[i3A + 2] + lambda * frcB[i3A + 2];
+      frc[j3A] += (1 - lambda) * frcA[j3A] + lambda * frcB[j3A];
+      frc[j3A + 1] += (1 - lambda) * frcA[j3A + 1] + lambda * frcB[j3A + 1];
+      frc[j3A + 2] += (1 - lambda) * frcA[j3A + 2] + lambda * frcB[j3A + 2];
+
+      morseE += e;
+      potentialEnergy += e;
+      dVdLambdaTotal += eB - eA; // ∂V/∂λ for bonded = V_B − V_A
+    } else {
+      // Normal (non-alchemical) bond
+      const e = morseBondForce(
+        pos,
+        frc,
+        bp.i,
+        bp.j,
+        bp.De,
+        bp.alpha,
+        bp.re,
+        pbcBoxSize,
+      );
+      morseE += e;
+      potentialEnergy += e;
+    }
   }
 
   // 2. Angle forces (harmonic) — using precomputed params
@@ -689,34 +849,128 @@ function computeAllForces(pos: Float64Array, frc: Float64Array): number {
       const is14 = scale14Set.has(key);
       const scaleFactor = is14 ? SCALE_14 : 1.0;
 
-      const { sigma, epsilon } = getLJCached(
-        atomicNumbers[i],
-        atomicNumbers[j],
-      );
-      const eLJ = ljForce(
-        pos,
-        frc,
-        i,
-        j,
-        sigma,
-        epsilon * scaleFactor,
-        cutoff,
-        pbcBoxSize,
-      );
-      ljE += eLJ;
-      potentialEnergy += eLJ;
-      const eCoul = coulombForce(
-        pos,
-        frc,
-        i,
-        j,
-        charges[i] * scaleFactor,
-        charges[j],
-        wc,
-        pbcBoxSize,
-      );
-      coulombE += eCoul;
-      potentialEnergy += eCoul;
+      // FEP: use soft-core LJ for pairs involving alchemical atoms
+      const pairIsAlchemical =
+        fepActive && (fepAlchemicalSet.has(i) || fepAlchemicalSet.has(j));
+
+      if (pairIsAlchemical) {
+        // --- Soft-core LJ with λ-interpolation ---
+        // State A: standard LJ with state A params, scaled by (1−λ)
+        // State B: soft-core LJ with state B params, scaled by λ
+        // This ensures smooth decoupling/coupling of alchemical atoms.
+        // Reference: Beutler et al., Chem. Phys. Lett. 222, 529 (1994)
+
+        // State A LJ (scaled by 1−λ using soft-core with flipped λ)
+        const { sigma: sigA, epsilon: epsA } = getLJCached(
+          atomicNumbers[i],
+          atomicNumbers[j],
+        );
+        const [eLJ_A, dVdL_A] = softCoreLJForce(
+          pos,
+          frc,
+          i,
+          j,
+          sigA,
+          epsA * scaleFactor,
+          1 - lambda,
+          fepConfig.softCoreAlpha,
+          fepConfig.softCorePower,
+          cutoff,
+          pbcBoxSize,
+        );
+        ljE += eLJ_A;
+        potentialEnergy += eLJ_A;
+        dVdLambdaTotal -= dVdL_A; // negative because d(1−λ)/dλ = −1
+
+        // State B LJ (scaled by λ using soft-core)
+        const { sigma: sigB, epsilon: epsB } = getLJCached(
+          atomicNumbersB[i] || atomicNumbers[i],
+          atomicNumbersB[j] || atomicNumbers[j],
+        );
+        const [eLJ_B, dVdL_B] = softCoreLJForce(
+          pos,
+          frc,
+          i,
+          j,
+          sigB,
+          epsB * scaleFactor,
+          lambda,
+          fepConfig.softCoreAlpha,
+          fepConfig.softCorePower,
+          cutoff,
+          pbcBoxSize,
+        );
+        ljE += eLJ_B;
+        potentialEnergy += eLJ_B;
+        dVdLambdaTotal += dVdL_B;
+
+        // Coulomb: linear interpolation of charges
+        // q(λ) = (1−λ)·qA + λ·qB for alchemical atoms
+        const qiA = charges[i] * scaleFactor;
+        const qjA = charges[j];
+        const qiB = chargesB[i] * scaleFactor;
+        const qjB = chargesB[j];
+        const qi = (1 - lambda) * qiA + lambda * qiB;
+        const qj = (1 - lambda) * qjA + lambda * qjB;
+        const eCoul = coulombForce(pos, frc, i, j, qi, qj, wc, pbcBoxSize);
+        coulombE += eCoul;
+        potentialEnergy += eCoul;
+
+        // ∂V_coul/∂λ: compute Coulomb at state A and state B params
+        // and take the difference for the derivative
+        const frcDummy = new Float64Array(frc.length);
+        const eCoulA = coulombForce(
+          pos,
+          frcDummy,
+          i,
+          j,
+          qiA,
+          qjA,
+          wc,
+          pbcBoxSize,
+        );
+        const eCoulB = coulombForce(
+          pos,
+          frcDummy,
+          i,
+          j,
+          qiB,
+          qjB,
+          wc,
+          pbcBoxSize,
+        );
+        dVdLambdaTotal += eCoulB - eCoulA;
+      } else {
+        // Standard (non-alchemical) pair
+        const { sigma, epsilon } = getLJCached(
+          atomicNumbers[i],
+          atomicNumbers[j],
+        );
+        const eLJ = ljForce(
+          pos,
+          frc,
+          i,
+          j,
+          sigma,
+          epsilon * scaleFactor,
+          cutoff,
+          pbcBoxSize,
+        );
+        ljE += eLJ;
+        potentialEnergy += eLJ;
+        const eCoul = coulombForce(
+          pos,
+          frc,
+          i,
+          j,
+          charges[i] * scaleFactor,
+          charges[j],
+          wc,
+          pbcBoxSize,
+        );
+        coulombE += eCoul;
+        potentialEnergy += eCoul;
+      }
     };
 
     if (nAtoms < 50) {
@@ -759,6 +1013,9 @@ function computeAllForces(pos: Float64Array, frc: Float64Array): number {
     lj: ljE,
     coulomb: coulombE,
   };
+
+  // Cache FEP derivative for sample collection
+  cachedDVDLambda = dVdLambdaTotal;
 
   return potentialEnergy;
 }
@@ -1314,6 +1571,229 @@ function runNEBComputation(
   self.postMessage(resultMsg);
 }
 
+// ---- FEP Scan ----
+/**
+ * Run a complete FEP scan across all λ windows.
+ * For each λ: equilibrate, then collect production samples.
+ * Results are sent back as they accumulate, with a final FEPResult message.
+ *
+ * The scan runs synchronously within this function, yielding control
+ * back to the event loop between windows via setTimeout to allow
+ * cancellation messages to be processed.
+ */
+function runFEPScan(): void {
+  if (!fepConfig.enabled || fepConfig.alchemicalAtoms.length === 0) return;
+
+  fepScanActive = true;
+  fepScanCancelled = false;
+  fepSamples = [];
+
+  // Enforce Nosé-Hoover thermostat for canonical ensemble sampling
+  // Reference: Shirts & Chodera, J. Chem. Phys. 129, 124105 (2008)
+  if (config.thermostat !== 'nose-hoover') {
+    config.thermostat = 'nose-hoover';
+    nhChainState = createNoseHooverChainState(
+      nAtoms,
+      config.temperature,
+      config.thermostatTau,
+    );
+  }
+
+  const schedule = fepConfig.lambdaSchedule;
+  let windowIndex = 0;
+
+  function runNextWindow(): void {
+    if (fepScanCancelled || windowIndex >= schedule.length) {
+      // Scan complete or cancelled — compute final result
+      finishFEPScan();
+      return;
+    }
+
+    const currentLambda = schedule[windowIndex];
+    fepConfig.lambda = currentLambda;
+    rebuildFEPParams();
+
+    // --- Equilibration phase ---
+    const progress: FEPProgress = {
+      phase: 'equilibrating',
+      currentWindowIndex: windowIndex,
+      totalWindows: schedule.length,
+      stepsInWindow: 0,
+      totalStepsInWindow:
+        fepConfig.equilibrationSteps + fepConfig.productionSteps,
+      totalSamplesCollected: fepSamples.length,
+    };
+    self.postMessage({ type: 'fep-progress', progress });
+
+    // Run equilibration in chunks to allow cancellation
+    let eqStepsRemaining = fepConfig.equilibrationSteps;
+    const CHUNK_SIZE = 50;
+
+    function equilibrate(): void {
+      if (fepScanCancelled) {
+        finishFEPScan();
+        return;
+      }
+
+      const chunk = Math.min(CHUNK_SIZE, eqStepsRemaining);
+      if (chunk > 0) {
+        runSteps(chunk);
+        eqStepsRemaining -= chunk;
+        setTimeout(equilibrate, 0);
+      } else {
+        // Equilibration done — start production
+        startProduction();
+      }
+    }
+
+    function startProduction(): void {
+      const progressProd: FEPProgress = {
+        phase: 'collecting',
+        currentWindowIndex: windowIndex,
+        totalWindows: schedule.length,
+        stepsInWindow: fepConfig.equilibrationSteps,
+        totalStepsInWindow:
+          fepConfig.equilibrationSteps + fepConfig.productionSteps,
+        totalSamplesCollected: fepSamples.length,
+      };
+      self.postMessage({ type: 'fep-progress', progress: progressProd });
+
+      let prodStepsRemaining = fepConfig.productionSteps;
+      const windowSamples: FEPSample[] = [];
+
+      function collectProduction(): void {
+        if (fepScanCancelled) {
+          finishFEPScan();
+          return;
+        }
+
+        const chunk = Math.min(CHUNK_SIZE, prodStepsRemaining);
+        if (chunk > 0) {
+          // Run chunk and collect samples
+          for (let s = 0; s < chunk; s++) {
+            // Run one step manually (using the CPU path)
+            if (config.thermostat === 'nose-hoover' && nhChainState) {
+              const ke = computeKineticEnergy();
+              noseHooverChainStep(
+                velocities,
+                masses,
+                fixed,
+                ke,
+                config.temperature,
+                config.timestep * 0.5,
+                nhChainState,
+              );
+            }
+
+            velocityVerletStep(
+              positions,
+              velocities,
+              forces,
+              masses,
+              fixed,
+              config.timestep,
+              computeAllForces,
+            );
+
+            if (box.periodic) {
+              wrapPositions(positions, nAtoms, box.size);
+            }
+
+            const kineticEnergy = computeKineticEnergy();
+            if (config.thermostat === 'nose-hoover' && nhChainState) {
+              noseHooverChainStep(
+                velocities,
+                masses,
+                fixed,
+                kineticEnergy,
+                config.temperature,
+                config.timestep * 0.5,
+                nhChainState,
+              );
+            }
+
+            step++;
+
+            // Collect sample at specified interval
+            if (step % fepConfig.collectInterval === 0) {
+              windowSamples.push({
+                lambda: currentLambda,
+                dVdLambda: cachedDVDLambda,
+                deltaV: cachedDVDLambda, // For single-topology, ΔV ≈ ∂V/∂λ
+                step,
+              });
+            }
+          }
+
+          prodStepsRemaining -= chunk;
+          setTimeout(collectProduction, 0);
+        } else {
+          // Production done for this window
+          fepSamples.push(...windowSamples);
+
+          // Send window samples
+          self.postMessage({
+            type: 'fep-samples',
+            samples: windowSamples,
+          });
+
+          // Move to next window
+          windowIndex++;
+          setTimeout(runNextWindow, 0);
+        }
+      }
+
+      collectProduction();
+    }
+
+    equilibrate();
+  }
+
+  runNextWindow();
+}
+
+/**
+ * Finish an FEP scan — compute the free energy result and send it.
+ */
+function finishFEPScan(): void {
+  fepScanActive = false;
+
+  if (fepSamples.length > 0) {
+    const tiResult = computeTI(fepSamples, fepConfig.lambdaSchedule);
+    const zwanzigResult = computeZwanzig(
+      fepSamples,
+      fepConfig.lambdaSchedule,
+      config.temperature,
+    );
+
+    // Use TI as the primary result (more robust for wide λ windows)
+    self.postMessage({
+      type: 'fep-result',
+      result: tiResult,
+    });
+
+    // Also send Zwanzig result for comparison
+    self.postMessage({
+      type: 'fep-result',
+      result: zwanzigResult,
+    });
+  }
+
+  const progressComplete: FEPProgress = {
+    phase: 'complete',
+    currentWindowIndex: fepConfig.lambdaSchedule.length,
+    totalWindows: fepConfig.lambdaSchedule.length,
+    stepsInWindow: 0,
+    totalStepsInWindow: 0,
+    totalSamplesCollected: fepSamples.length,
+  };
+  self.postMessage({ type: 'fep-progress', progress: progressComplete });
+
+  // Send final state update
+  rebuildTopology();
+  sendState();
+}
+
 // ---- Send state back to main thread ----
 function sendState(): void {
   let potentialEnergy: number;
@@ -1525,6 +2005,29 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
         );
       }
       sendState();
+      break;
+
+    case 'fep-config':
+      fepConfig = { ...msg.config };
+      rebuildFEPParams();
+      sendState();
+      break;
+
+    case 'fep-set-lambda':
+      fepConfig.lambda = msg.lambda;
+      cachedEnergiesValid = false;
+      sendState();
+      break;
+
+    case 'fep-start-scan':
+      if (!fepScanActive) {
+        stopLoop();
+        runFEPScan();
+      }
+      break;
+
+    case 'fep-cancel':
+      fepScanCancelled = true;
       break;
   }
 };

--- a/src/io/chemsimFile.ts
+++ b/src/io/chemsimFile.ts
@@ -18,6 +18,9 @@ import type {
   ColorMode,
   Hybridization,
   BondType,
+  AlchemicalAtom,
+  FEPSample,
+  FEPResult,
 } from '../data/types';
 
 // --------------- Schema Types ---------------
@@ -56,6 +59,13 @@ export interface ChemSimFileV1 {
   box: SimulationBox;
   ui: SavedUISettings;
   metadata: LessonMetadata;
+  /** Optional FEP (Free Energy Perturbation) state — backward compatible */
+  fep?: {
+    alchemicalAtoms: AlchemicalAtom[];
+    lambdaSchedule: number[];
+    samples: FEPSample[];
+    result?: FEPResult;
+  };
 }
 
 // --------------- Serialize / Deserialize ---------------

--- a/src/store/simulationStore.ts
+++ b/src/store/simulationStore.ts
@@ -9,6 +9,10 @@ import type {
   Atom,
   Bond,
   EnergyBreakdown,
+  FEPConfig,
+  FEPProgress,
+  FEPResult,
+  FEPSample,
   MoleculeInfo,
   NEBConfig,
   NEBResult,
@@ -21,6 +25,7 @@ import type {
   WorkerStateUpdate,
 } from '../data/types';
 import { DEFAULT_NEB_CONFIG } from '../data/types';
+import { DEFAULT_FEP_CONFIG } from '../data/types';
 import elements from '../data/elements';
 import { SimulationWorker } from '../worker-comms';
 import {
@@ -139,6 +144,18 @@ export interface SimulationStoreState {
   runNEB: (config?: Partial<NEBConfig>) => void;
   cancelNEB: () => void;
   clearNEBResult: () => void;
+
+  // ---- FEP (Free Energy Perturbation) ----
+  fepConfig: FEPConfig;
+  fepSamples: FEPSample[];
+  fepResult: FEPResult | null;
+  fepProgress: FEPProgress | null;
+  fepRunning: boolean;
+  configureFEP: (config: Partial<FEPConfig>) => void;
+  setFEPLambda: (lambda: number) => void;
+  startFEPScan: () => void;
+  cancelFEP: () => void;
+  clearFEPResult: () => void;
 }
 
 const DEFAULT_CONFIG: SimulationConfig = {
@@ -284,6 +301,13 @@ function buildStoreSlice(
     nebReactantPositions: null,
     nebProductPositions: null,
 
+    // FEP state
+    fepConfig: { ...DEFAULT_FEP_CONFIG },
+    fepSamples: [],
+    fepResult: null,
+    fepProgress: null,
+    fepRunning: false,
+
     async initWorker() {
       const worker = new SimulationWorker();
       await worker.waitReady();
@@ -301,6 +325,19 @@ function buildStoreSlice(
           nebRunning: false,
           nebProgress: null,
         });
+      });
+      worker.onFEPSamplesUpdate((samples) => {
+        const existing = get().fepSamples;
+        set({ fepSamples: [...existing, ...samples] });
+      });
+      worker.onFEPProgressUpdate((progress) => {
+        set({ fepProgress: progress });
+        if (progress.phase === 'complete') {
+          set({ fepRunning: false });
+        }
+      });
+      worker.onFEPResultUpdate((result) => {
+        set({ fepResult: result });
       });
       set({ worker });
     },
@@ -843,6 +880,62 @@ function buildStoreSlice(
         nebProgress: null,
         nebReactantPositions: null,
         nebProductPositions: null,
+      });
+    },
+
+    // ---- FEP actions ----
+
+    configureFEP(partialConfig: Partial<FEPConfig>) {
+      const current = get().fepConfig;
+      const merged = { ...current, ...partialConfig };
+      set({ fepConfig: merged });
+      const worker = get().worker;
+      if (worker) {
+        worker.configureFEP(merged);
+      }
+    },
+
+    setFEPLambda(lambda: number) {
+      const fepConfig = get().fepConfig;
+      set({ fepConfig: { ...fepConfig, lambda } });
+      const worker = get().worker;
+      if (worker) {
+        worker.setFEPLambda(lambda);
+      }
+    },
+
+    startFEPScan() {
+      const worker = get().worker;
+      if (!worker) return;
+
+      // First, send the current FEP config to make sure worker is in sync
+      const fepConfig = get().fepConfig;
+      worker.configureFEP(fepConfig);
+
+      // Clear previous results
+      set({
+        fepRunning: true,
+        fepSamples: [],
+        fepResult: null,
+        fepProgress: null,
+      });
+
+      worker.startFEPScan();
+    },
+
+    cancelFEP() {
+      const worker = get().worker;
+      if (worker) {
+        worker.cancelFEP();
+      }
+      set({ fepRunning: false });
+    },
+
+    clearFEPResult() {
+      set({
+        fepResult: null,
+        fepProgress: null,
+        fepSamples: [],
       });
     },
   };

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -45,6 +45,7 @@ interface UIStore {
   showExperimentPanel: boolean;
   showCrystalBuilder: boolean;
   showNEBPanel: boolean;
+  showFEPPanel: boolean;
   togglePeriodicTable: () => void;
   togglePropertyPanel: () => void;
   toggleEnergyPlot: () => void;
@@ -55,6 +56,7 @@ interface UIStore {
   toggleExperimentPanel: () => void;
   toggleCrystalBuilder: () => void;
   toggleNEBPanel: () => void;
+  toggleFEPPanel: () => void;
 
   // ---- Quantity dashboard ----
   showDashboard: boolean;
@@ -169,6 +171,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   showExperimentPanel: false,
   showCrystalBuilder: false,
   showNEBPanel: false,
+  showFEPPanel: false,
   hoveredAtomId: null,
 
   // Quantity dashboard
@@ -230,6 +233,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   toggleCrystalBuilder: () =>
     set({ showCrystalBuilder: !get().showCrystalBuilder }),
   toggleNEBPanel: () => set({ showNEBPanel: !get().showNEBPanel }),
+  toggleFEPPanel: () => set({ showFEPPanel: !get().showFEPPanel }),
 
   toggleDashboard: () => set({ showDashboard: !get().showDashboard }),
   toggleDashboardCard: (cardId: string) => {

--- a/src/ui/FEPPanel.tsx
+++ b/src/ui/FEPPanel.tsx
@@ -1,0 +1,471 @@
+// ==============================================================
+// FEPPanel — controls for Free Energy Perturbation calculations
+//
+// Allows the user to:
+// 1. Select alchemical atoms and their target elements
+// 2. Configure λ schedule and sampling parameters
+// 3. Run FEP/TI scans and view results
+// ==============================================================
+
+import React, { useState, useCallback } from 'react';
+import { useUIStore } from '../store/uiStore';
+import { useSimContextStore } from '../store/SimulationContext';
+import type { AlchemicalAtom, FEPConfig } from '../data/types';
+import { DEFAULT_FEP_CONFIG } from '../data/types';
+import elements from '../data/elements';
+
+const panelStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 10,
+  right: 10,
+  width: 300,
+  maxHeight: 'calc(100vh - 20px)',
+  overflowY: 'auto',
+  background: 'rgba(20, 20, 35, 0.95)',
+  border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: 8,
+  padding: 12,
+  color: '#eee',
+  fontSize: 12,
+  zIndex: 200,
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 10,
+};
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: 10,
+  padding: 8,
+  background: 'rgba(255,255,255,0.03)',
+  borderRadius: 6,
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  marginBottom: 4,
+  color: '#aaa',
+  fontSize: 11,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '4px 6px',
+  background: 'rgba(255,255,255,0.08)',
+  border: '1px solid rgba(255,255,255,0.15)',
+  borderRadius: 4,
+  color: '#eee',
+  fontSize: 12,
+  boxSizing: 'border-box',
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  borderRadius: 4,
+  border: '1px solid rgba(255,255,255,0.2)',
+  background: 'rgba(60,100,200,0.4)',
+  color: '#eee',
+  cursor: 'pointer',
+  fontSize: 12,
+  width: '100%',
+};
+
+const dangerButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  background: 'rgba(200,60,60,0.4)',
+};
+
+const resultStyle: React.CSSProperties = {
+  padding: 8,
+  background: 'rgba(40,120,40,0.15)',
+  borderRadius: 6,
+  border: '1px solid rgba(40,120,40,0.3)',
+  marginBottom: 10,
+};
+
+const progressBarOuter: React.CSSProperties = {
+  width: '100%',
+  height: 6,
+  background: 'rgba(255,255,255,0.1)',
+  borderRadius: 3,
+  marginTop: 4,
+  marginBottom: 4,
+};
+
+export function FEPPanel(): React.ReactElement | null {
+  const showFEPPanel = useUIStore((s) => s.showFEPPanel);
+  const toggleFEPPanel = useUIStore((s) => s.toggleFEPPanel);
+
+  const store = useSimContextStore();
+  const atoms = store((s) => s.atoms);
+  const selectedAtomIds = useUIStore((s) => s.selectedAtomIds);
+
+  const fepConfig = store((s) => s.fepConfig);
+  const fepResult = store((s) => s.fepResult);
+  const fepProgress = store((s) => s.fepProgress);
+  const fepRunning = store((s) => s.fepRunning);
+  const configureFEP = store((s) => s.configureFEP);
+  const startFEPScan = store((s) => s.startFEPScan);
+  const cancelFEP = store((s) => s.cancelFEP);
+  const clearFEPResult = store((s) => s.clearFEPResult);
+
+  // Local state for the target element number
+  const [targetElement, setTargetElement] = useState(2); // default: He
+  const [nWindows, setNWindows] = useState(11);
+  const [eqSteps, setEqSteps] = useState(DEFAULT_FEP_CONFIG.equilibrationSteps);
+  const [prodSteps, setProdSteps] = useState(
+    DEFAULT_FEP_CONFIG.productionSteps,
+  );
+
+  const handleAddAlchemicalAtom = useCallback(() => {
+    if (selectedAtomIds.length === 0) return;
+
+    const newAlchemical: AlchemicalAtom[] = [...fepConfig.alchemicalAtoms];
+    for (const atomId of selectedAtomIds) {
+      // Find the atom's current properties
+      const atom = atoms.find((a) => a.id === atomId);
+      if (!atom) continue;
+
+      // Skip if already alchemical
+      if (newAlchemical.some((aa) => aa.atomIndex === atomId)) continue;
+
+      newAlchemical.push({
+        atomIndex: atomId,
+        stateA: {
+          elementNumber: atom.elementNumber,
+          charge: atom.charge,
+          hybridization: atom.hybridization,
+        },
+        stateB: {
+          elementNumber: targetElement,
+          charge: 0, // Will be recomputed by Gasteiger
+          hybridization: 'sp3', // Default, will be detected
+        },
+      });
+    }
+
+    configureFEP({ alchemicalAtoms: newAlchemical, enabled: true });
+  }, [
+    selectedAtomIds,
+    atoms,
+    targetElement,
+    fepConfig.alchemicalAtoms,
+    configureFEP,
+  ]);
+
+  const handleRemoveAlchemicalAtom = useCallback(
+    (atomIndex: number) => {
+      const filtered = fepConfig.alchemicalAtoms.filter(
+        (aa) => aa.atomIndex !== atomIndex,
+      );
+      configureFEP({
+        alchemicalAtoms: filtered,
+        enabled: filtered.length > 0,
+      });
+    },
+    [fepConfig.alchemicalAtoms, configureFEP],
+  );
+
+  const handleStartScan = useCallback(() => {
+    // Build λ schedule from nWindows
+    const schedule: number[] = [];
+    for (let i = 0; i < nWindows; i++) {
+      schedule.push(i / (nWindows - 1));
+    }
+
+    const newConfig: Partial<FEPConfig> = {
+      lambdaSchedule: schedule,
+      equilibrationSteps: eqSteps,
+      productionSteps: prodSteps,
+      enabled: true,
+    };
+    configureFEP(newConfig);
+
+    // Short delay to ensure config is sent before starting scan
+    setTimeout(() => startFEPScan(), 50);
+  }, [nWindows, eqSteps, prodSteps, configureFEP, startFEPScan]);
+
+  if (!showFEPPanel) return null;
+
+  // Progress bar computation
+  const progressFraction =
+    fepProgress && fepProgress.totalWindows > 0
+      ? (fepProgress.currentWindowIndex +
+          (fepProgress.totalStepsInWindow > 0
+            ? fepProgress.stepsInWindow / fepProgress.totalStepsInWindow
+            : 0)) /
+        fepProgress.totalWindows
+      : 0;
+
+  return (
+    <div style={panelStyle}>
+      {/* Header */}
+      <div style={headerStyle}>
+        <strong>Free Energy Perturbation</strong>
+        <button
+          onClick={toggleFEPPanel}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#888',
+            cursor: 'pointer',
+            fontSize: 16,
+          }}
+        >
+          x
+        </button>
+      </div>
+
+      {/* Alchemical atoms section */}
+      <div style={sectionStyle}>
+        <div style={{ ...labelStyle, fontWeight: 'bold', color: '#ccc' }}>
+          Alchemical Atoms
+        </div>
+        <div style={{ marginBottom: 6, color: '#999', fontSize: 11 }}>
+          Select atom(s), choose target element, then click "Add".
+        </div>
+
+        {/* Target element selector */}
+        <label style={labelStyle}>
+          Target element:
+          <select
+            value={targetElement}
+            onChange={(e) => setTargetElement(Number(e.target.value))}
+            style={{ ...inputStyle, marginTop: 2 }}
+          >
+            {Object.values(elements)
+              .filter((el) => el && el.number <= 36)
+              .map((el) => (
+                <option key={el.number} value={el.number}>
+                  {el.symbol} — {el.name}
+                </option>
+              ))}
+          </select>
+        </label>
+
+        <button
+          onClick={handleAddAlchemicalAtom}
+          style={{
+            ...buttonStyle,
+            background: 'rgba(40,80,40,0.5)',
+            marginTop: 4,
+          }}
+          disabled={selectedAtomIds.length === 0 || fepRunning}
+        >
+          Add selected atom(s) ({selectedAtomIds.length})
+        </button>
+
+        {/* List of alchemical atoms */}
+        {fepConfig.alchemicalAtoms.length > 0 && (
+          <div style={{ marginTop: 8 }}>
+            {fepConfig.alchemicalAtoms.map((aa) => {
+              const elA = elements[aa.stateA.elementNumber];
+              const elB = elements[aa.stateB.elementNumber];
+              return (
+                <div
+                  key={aa.atomIndex}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '3px 6px',
+                    marginBottom: 2,
+                    background: 'rgba(255,255,255,0.05)',
+                    borderRadius: 4,
+                    fontSize: 11,
+                  }}
+                >
+                  <span>
+                    Atom {aa.atomIndex}: {elA?.symbol ?? '?'} →{' '}
+                    {elB?.symbol ?? '?'}
+                  </span>
+                  <button
+                    onClick={() => handleRemoveAlchemicalAtom(aa.atomIndex)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#c66',
+                      cursor: 'pointer',
+                      fontSize: 11,
+                    }}
+                    disabled={fepRunning}
+                  >
+                    remove
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Configuration section */}
+      <div style={sectionStyle}>
+        <div style={{ ...labelStyle, fontWeight: 'bold', color: '#ccc' }}>
+          Scan Configuration
+        </div>
+
+        <label style={labelStyle}>
+          Number of λ windows:
+          <input
+            type="number"
+            min={3}
+            max={51}
+            value={nWindows}
+            onChange={(e) => setNWindows(Number(e.target.value))}
+            style={{ ...inputStyle, marginTop: 2 }}
+            disabled={fepRunning}
+          />
+        </label>
+
+        <label style={labelStyle}>
+          Equilibration steps per window:
+          <input
+            type="number"
+            min={100}
+            step={100}
+            value={eqSteps}
+            onChange={(e) => setEqSteps(Number(e.target.value))}
+            style={{ ...inputStyle, marginTop: 2 }}
+            disabled={fepRunning}
+          />
+        </label>
+
+        <label style={labelStyle}>
+          Production steps per window:
+          <input
+            type="number"
+            min={100}
+            step={100}
+            value={prodSteps}
+            onChange={(e) => setProdSteps(Number(e.target.value))}
+            style={{ ...inputStyle, marginTop: 2 }}
+            disabled={fepRunning}
+          />
+        </label>
+      </div>
+
+      {/* Run / Cancel buttons */}
+      <div style={{ marginBottom: 10 }}>
+        {!fepRunning ? (
+          <button
+            onClick={handleStartScan}
+            style={buttonStyle}
+            disabled={fepConfig.alchemicalAtoms.length === 0}
+          >
+            Run FEP Scan
+          </button>
+        ) : (
+          <button onClick={cancelFEP} style={dangerButtonStyle}>
+            Cancel Scan
+          </button>
+        )}
+      </div>
+
+      {/* Progress */}
+      {fepProgress && fepRunning && (
+        <div style={sectionStyle}>
+          <div style={{ ...labelStyle, fontWeight: 'bold', color: '#ccc' }}>
+            Progress
+          </div>
+          <div style={{ fontSize: 11, color: '#aaa', marginBottom: 4 }}>
+            Window {fepProgress.currentWindowIndex + 1}/
+            {fepProgress.totalWindows} — {fepProgress.phase}
+          </div>
+          <div style={progressBarOuter}>
+            <div
+              style={{
+                width: `${Math.min(100, progressFraction * 100)}%`,
+                height: '100%',
+                background: 'rgba(60,150,255,0.7)',
+                borderRadius: 3,
+                transition: 'width 0.3s',
+              }}
+            />
+          </div>
+          <div style={{ fontSize: 10, color: '#888' }}>
+            {fepProgress.totalSamplesCollected} samples collected
+          </div>
+        </div>
+      )}
+
+      {/* Results */}
+      {fepResult && (
+        <div style={resultStyle}>
+          <div style={{ fontWeight: 'bold', marginBottom: 4, color: '#8f8' }}>
+            Result ({fepResult.method})
+          </div>
+          <div style={{ fontSize: 13, marginBottom: 2 }}>
+            ΔG = {fepResult.deltaG.toFixed(4)} ± {fepResult.error.toFixed(4)} eV
+          </div>
+          <div style={{ fontSize: 11, color: '#aaa' }}>
+            = {(fepResult.deltaG * 96.485).toFixed(2)} ±{' '}
+            {(fepResult.error * 96.485).toFixed(2)} kJ/mol
+          </div>
+
+          {/* TI curve: ⟨∂V/∂λ⟩ vs λ */}
+          {fepResult.dVdLambdaMeans.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              <div style={{ fontSize: 10, color: '#888', marginBottom: 2 }}>
+                ⟨∂V/∂λ⟩ vs λ:
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  height: 40,
+                  gap: 1,
+                }}
+              >
+                {fepResult.dVdLambdaMeans.map((mean, idx) => {
+                  const maxAbs = Math.max(
+                    ...fepResult.dVdLambdaMeans.map(Math.abs),
+                    1e-10,
+                  );
+                  const normalized = Math.abs(mean) / maxAbs;
+                  const color =
+                    mean >= 0 ? 'rgba(60,150,255,0.6)' : 'rgba(255,100,60,0.6)';
+                  return (
+                    <div
+                      key={idx}
+                      style={{
+                        flex: 1,
+                        height: `${normalized * 100}%`,
+                        minHeight: 1,
+                        background: color,
+                        borderRadius: 1,
+                      }}
+                      title={`λ=${fepResult.lambdaSchedule[idx]?.toFixed(2)}: ${mean.toFixed(4)} eV`}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          <button
+            onClick={clearFEPResult}
+            style={{
+              ...buttonStyle,
+              background: 'rgba(100,100,100,0.3)',
+              marginTop: 8,
+              fontSize: 11,
+            }}
+          >
+            Clear Result
+          </button>
+        </div>
+      )}
+
+      {/* Info */}
+      <div style={{ fontSize: 10, color: '#666', lineHeight: 1.4 }}>
+        Free energy perturbation computes ΔG between two states using
+        thermodynamic integration. Requires Nosé-Hoover thermostat
+        (auto-enabled).
+      </div>
+    </div>
+  );
+}

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -131,6 +131,8 @@ export const Toolbar: React.FC = () => {
   const toggleAnnotationDipole = useUIStore((s) => s.toggleAnnotationDipole);
   const showNEBPanel = useUIStore((s) => s.showNEBPanel);
   const toggleNEBPanel = useUIStore((s) => s.toggleNEBPanel);
+  const showFEPPanel = useUIStore((s) => s.showFEPPanel);
+  const toggleFEPPanel = useUIStore((s) => s.toggleFEPPanel);
 
   // When selecting the place-molecule tool, show the encounter panel
   const handleToolSelect = useCallback(
@@ -694,6 +696,30 @@ export const Toolbar: React.FC = () => {
         }}
       >
         NEB
+      </button>
+
+      {/* FEP free energy toggle */}
+      <button
+        data-testid="toggle-fep-panel"
+        onClick={toggleFEPPanel}
+        title="Free Energy Perturbation"
+        style={{
+          width: 40,
+          height: 30,
+          borderRadius: 4,
+          border: showFEPPanel
+            ? '2px solid #a5fac4'
+            : '1px solid rgba(255,255,255,0.15)',
+          background: showFEPPanel
+            ? 'rgba(165,250,196,0.3)'
+            : 'rgba(40,40,60,0.8)',
+          color: '#fff',
+          cursor: 'pointer',
+          fontSize: 9,
+          fontFamily: 'monospace',
+        }}
+      >
+        FEP
       </button>
     </div>
   );

--- a/src/worker-comms.ts
+++ b/src/worker-comms.ts
@@ -6,6 +6,10 @@
 import type {
   Atom,
   Bond,
+  FEPConfig,
+  FEPProgress,
+  FEPResult,
+  FEPSample,
   NEBConfig,
   NEBResult,
   SimulationBox,
@@ -22,12 +26,18 @@ export type NEBProgressCallback = (
   maxForce: number,
 ) => void;
 export type NEBResultCallback = (result: NEBResult) => void;
+export type FEPSamplesCallback = (samples: FEPSample[]) => void;
+export type FEPProgressCallback = (progress: FEPProgress) => void;
+export type FEPResultCallback = (result: FEPResult) => void;
 
 export class SimulationWorker {
   private worker: Worker;
   private onState: StateCallback | null = null;
   private onNEBProgress: NEBProgressCallback | null = null;
   private onNEBResult: NEBResultCallback | null = null;
+  private onFEPSamples: FEPSamplesCallback | null = null;
+  private onFEPProgress: FEPProgressCallback | null = null;
+  private onFEPResult: FEPResultCallback | null = null;
   private readyPromise: Promise<void>;
 
   constructor() {
@@ -55,6 +65,12 @@ export class SimulationWorker {
         );
       } else if (e.data.type === 'neb-result' && this.onNEBResult) {
         this.onNEBResult(e.data.result);
+      } else if (e.data.type === 'fep-samples' && this.onFEPSamples) {
+        this.onFEPSamples(e.data.samples);
+      } else if (e.data.type === 'fep-progress' && this.onFEPProgress) {
+        this.onFEPProgress(e.data.progress);
+      } else if (e.data.type === 'fep-result' && this.onFEPResult) {
+        this.onFEPResult(e.data.result);
       }
     };
   }
@@ -140,6 +156,36 @@ export class SimulationWorker {
 
   calm(): void {
     this.send({ type: 'calm' });
+  }
+
+  // ---- FEP methods ----
+
+  configureFEP(config: FEPConfig): void {
+    this.send({ type: 'fep-config', config });
+  }
+
+  setFEPLambda(lambda: number): void {
+    this.send({ type: 'fep-set-lambda', lambda });
+  }
+
+  startFEPScan(): void {
+    this.send({ type: 'fep-start-scan' });
+  }
+
+  cancelFEP(): void {
+    this.send({ type: 'fep-cancel' });
+  }
+
+  onFEPSamplesUpdate(callback: FEPSamplesCallback): void {
+    this.onFEPSamples = callback;
+  }
+
+  onFEPProgressUpdate(callback: FEPProgressCallback): void {
+    this.onFEPProgress = callback;
+  }
+
+  onFEPResultUpdate(callback: FEPResultCallback): void {
+    this.onFEPResult = callback;
   }
 
   terminate(): void {


### PR DESCRIPTION
Closes #29

## Summary
Implements Free Energy Perturbation (FEP) and Thermodynamic Integration (TI) for computing free energy differences between two molecular states. Users can select "alchemical" atoms to transform (e.g., Na → K), and the system smoothly interpolates forces via a λ parameter from 0 to 1 across multiple windows. This is the first browser-based free energy calculator.

## Changes
- **`src/data/types.ts`**: Added `AlchemicalAtom`, `FEPConfig`, `FEPSample`, `FEPResult`, `FEPPhase`, `FEPProgress` interfaces and `DEFAULT_FEP_CONFIG`. Added worker message types for FEP configuration, lambda updates, scan control, progress, and results.
- **`src/engine/forces/softCoreLJ.ts`** (new): Soft-core LJ potential (Beutler et al., Chem. Phys. Lett. 222, 529 (1994)) that prevents singularities when atoms appear/disappear. Returns both energy and ∂V/∂λ.
- **`src/engine/fep.ts`** (new): TI trapezoidal integration (`computeTI`) and Zwanzig exponential average (`computeZwanzig`) with block-averaging error estimation (Flyvbjerg & Petersen, 1989).
- **`src/engine/worker.ts`**: Added λ-interpolated force computation for alchemical atoms (bonded + non-bonded), dual parameter caching (`rebuildFEPParams`), FEP scan loop with equilibration/production phases, and message handlers.
- **`src/engine/tests.ts`**: 9 new physics tests (FEP-01 through FEP-09).
- **`src/worker-comms.ts`**: FEP message forwarding and callbacks.
- **`src/store/simulationStore.ts`**: FEP state, actions, and worker callback wiring.
- **`src/store/uiStore.ts`**: FEP panel visibility toggle.
- **`src/ui/FEPPanel.tsx`** (new): Full FEP control panel with alchemical atom selection, λ schedule configuration, scan controls, progress bar, and results display.
- **`src/ui/Toolbar.tsx`**: FEP toggle button.
- **`src/App.tsx`**: FEP panel rendering.
- **`src/io/chemsimFile.ts`**: Optional FEP field in file format (backward compatible).

## Test Results
- Physics tests: 109/109 passing (was 100/100 before — +9 FEP tests)
- Build: clean
- Type check: clean

## PR Checklist

### Purpose
- [x] This change contributes toward a stated goal (issue #29)
- [x] Specific improvement addressed: Free energy perturbation / thermodynamic integration

### Physics Accuracy
- [x] If force computation changed: gradient test still passes (FEP-04)
- [x] If integrator changed: NVE energy conservation tests still pass
- [x] New potential/force has a gradient consistency test (FEP-04)
- [x] No physics test tolerance was weakened

### Code Quality
- [x] No `any` types introduced
- [x] No `console.log` in production code
- [x] No duplicated logic
- [x] Functions < 50 lines where possible
- [x] Constants cite their source (Beutler 1994, Kirkwood 1935, Zwanzig 1954, Flyvbjerg 1989)

### Testing
- [x] All existing tests pass (100/100 unchanged)
- [x] New tests added for new functionality (9 FEP tests)
- [x] Tests would FAIL if the feature were broken
- [x] Tests are not tautological

### Performance
- [x] No unnecessary O(N²) in hot loops (soft-core uses same pair iteration)
- [x] No per-frame allocations in hot paths (FEP temp arrays allocated only for alchemical bonds)

### Documentation
- [x] Complex algorithms have inline comments with paper references

### Follow-ups
- [ ] GPU support for FEP (soft-core kernel needed for WebGPU path)
- [ ] Charge recomputation at intermediate λ via Gasteiger interpolation
- [ ] "Batch mode" for long FEP runs that may time out in browser